### PR TITLE
Implement HTTPS redirect and security headers

### DIFF
--- a/app/DEVELOPER_README.md
+++ b/app/DEVELOPER_README.md
@@ -246,3 +246,42 @@ Fix:
 - Do not commit `.env`.
 - Replace `SECRET_KEY` before shared/staging/prod environments.
 - Use HTTPS termination in non-local environments (reverse proxy or ingress).
+
+## 9. Running Behind a Reverse Proxy (HTTPS / Proxy Headers)
+
+In production the app is typically placed behind a reverse proxy (nginx, a cloud load balancer, Kubernetes ingress, etc.) that terminates TLS. The proxy then forwards plain HTTP to the app.
+
+When `ENV=production` is set, `HTTPSRedirectMiddleware` is enabled. Without proxy-header trust, the app always sees plain HTTP—even for requests that arrived over HTTPS—and will redirect every request to HTTPS indefinitely (**infinite redirect loop**).
+
+### Trusted proxy headers (recommended in-app fix)
+
+Start Uvicorn with `--proxy-headers` and restrict which upstream IPs may set those headers:
+
+```bash
+# Trust a specific proxy IP (recommended for production)
+uvicorn app.main:app --proxy-headers --forwarded-allow-ips=<proxy-ip> --host 0.0.0.0 --port 8000
+
+# Trust all upstream IPs (only use if the app is fully behind a controlled network)
+uvicorn app.main:app --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 8000
+```
+
+With `--proxy-headers` enabled, Uvicorn reads `X-Forwarded-Proto` from the proxy and reports the correct scheme to the middleware, preventing the redirect loop.
+
+### Preferred alternative: redirect at the proxy layer
+
+Handle HTTP→HTTPS redirection in nginx/ingress and remove the need for in-app middleware entirely. Example nginx snippet:
+
+```nginx
+server {
+    listen 80;
+    server_name example.com;
+    return 301 https://$host$request_uri;
+}
+```
+
+This is the simpler and more robust approach for most deployments.
+
+### Local development
+
+No action needed. `ENV` defaults to `development`, so `HTTPSRedirectMiddleware` is never added and the app runs over plain HTTP on `localhost:8000`.
+

--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
+    ENV: str = "development"  # development | staging | production
     DB_SERVER: str = "localhost"
     DB_NAME: str = "SwishVision"
     DB_DRIVER: str = "ODBC Driver 17 for SQL Server"

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -4,7 +4,17 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 
 def setup_middleware(app: FastAPI):
-    # HTTPS redirect only in production
+    # HTTPS redirect only in production.
+    # WARNING: HTTPSRedirectMiddleware determines the scheme from the raw
+    # incoming request. If this app runs behind a reverse proxy or ingress that
+    # terminates TLS (nginx, a cloud load-balancer, Kubernetes ingress, etc.),
+    # the app will always see plain-HTTP requests, causing an infinite redirect
+    # loop.  Preferred approach: handle the HTTP→HTTPS redirect at the
+    # proxy/ingress layer.  If you must do it in-app, run the ASGI server with
+    # proxy-header trust enabled, e.g.:
+    #   uvicorn app.main:app --proxy-headers --forwarded-allow-ips=<proxy-ip>
+    # so that X-Forwarded-Proto is honoured before this middleware inspects the
+    # scheme.
     if settings.ENV == "production":
         app.add_middleware(HTTPSRedirectMiddleware)
 

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -1,8 +1,13 @@
 from fastapi import FastAPI
+from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 from fastapi.middleware.cors import CORSMiddleware
-
+from app.config import settings
 
 def setup_middleware(app: FastAPI):
+    # HTTPS redirect only in production
+    if settings.ENV == "production":
+        app.add_middleware(HTTPSRedirectMiddleware)
+
     # CORS – allow React dev server and localhost origins
     app.add_middleware(
         CORSMiddleware,
@@ -22,5 +27,6 @@ def setup_middleware(app: FastAPI):
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["X-XSS-Protection"] = "1; mode=block"
-        # TODO: Add CSP header in production
+        if settings.ENV == "production":
+            response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
         return response

--- a/env.example
+++ b/env.example
@@ -5,7 +5,7 @@
 # ─────────────────────────────────────────────
 
 # ── App ──────────────────────────────────────
-APP_ENV=development           # development | staging | production
+ENV=development               # development | staging | production
 SECRET_KEY=your-secret-key-here
 DEBUG=True
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,105 @@
+"""Tests for middleware behaviour, specifically security headers and HTTPS redirect."""
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.middleware import setup_middleware
+
+
+def _make_app() -> FastAPI:
+    """Return a minimal FastAPI app with a single health endpoint."""
+    mini = FastAPI()
+
+    @mini.get("/health")
+    def health():
+        return {"ok": True}
+
+    return mini
+
+
+# ── HSTS header ───────────────────────────────────────────────────────────────
+
+def test_hsts_header_present_in_production(monkeypatch):
+    """Strict-Transport-Security must be set when ENV == 'production'."""
+    from app.config import settings
+    monkeypatch.setattr(settings, "ENV", "production")
+
+    app = _make_app()
+    setup_middleware(app)
+
+    # TestClient follows HTTPS redirects by default; raise_server_exceptions
+    # keeps transport errors visible while still returning 3xx responses.
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("https://testserver/health")
+
+    assert response.status_code == 200
+    assert "Strict-Transport-Security" in response.headers
+    assert "max-age=31536000" in response.headers["Strict-Transport-Security"]
+    assert "includeSubDomains" in response.headers["Strict-Transport-Security"]
+
+
+def test_hsts_header_absent_in_development():
+    """Strict-Transport-Security must NOT be set in non-production environments."""
+    # settings.ENV defaults to "development" – no monkeypatching needed.
+    app = _make_app()
+    setup_middleware(app)
+
+    client = TestClient(app)
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert "Strict-Transport-Security" not in response.headers
+
+
+# ── HTTPS redirect ────────────────────────────────────────────────────────────
+
+def test_http_redirects_to_https_in_production(monkeypatch):
+    """Plain-HTTP requests must be redirected to HTTPS when ENV == 'production'.
+
+    Note: In real deployments behind a TLS-terminating reverse proxy this
+    middleware can cause redirect loops unless the ASGI server is started with
+    --proxy-headers so that X-Forwarded-Proto is honoured.  See middleware.py
+    for the full explanation.
+    """
+    from app.config import settings
+    monkeypatch.setattr(settings, "ENV", "production")
+
+    app = _make_app()
+    setup_middleware(app)
+
+    # Disable redirect following so we can assert the 307 response itself.
+    client = TestClient(app, follow_redirects=False, raise_server_exceptions=False)
+    response = client.get("http://testserver/health")
+
+    assert response.status_code in (301, 307, 308)
+    location = response.headers.get("location", "")
+    assert location.startswith("https://"), (
+        f"Expected redirect to https://, got Location: {location!r}"
+    )
+
+
+def test_no_https_redirect_in_development():
+    """HTTP requests must NOT be redirected when ENV != 'production'."""
+    app = _make_app()
+    setup_middleware(app)
+
+    client = TestClient(app, follow_redirects=False)
+    response = client.get("http://testserver/health")
+
+    assert response.status_code == 200
+
+
+# ── Other security headers ────────────────────────────────────────────────────
+
+def test_static_security_headers_always_present():
+    """X-Content-Type-Options, X-Frame-Options, X-XSS-Protection must be set
+    regardless of environment."""
+    app = _make_app()
+    setup_middleware(app)
+
+    client = TestClient(app)
+    response = client.get("/health")
+
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("X-Frame-Options") == "DENY"
+    assert response.headers.get("X-XSS-Protection") == "1; mode=block"


### PR DESCRIPTION
Add HTTPS redirect middleware for production environment and set Strict-Transport-Security header.