### PR TITLE
Add password reset, admin reset and frontend routing

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,13 +1,16 @@
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, Header
 from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy import func
 from jose import jwt, JWTError
 from datetime import datetime, timezone
+from typing import Optional
+import secrets
 from app.database import get_db
 from app.models.user import User
 from app.models.revoked_token import RevokedToken
-from app.schemas.auth import RegisterRequest, LoginRequest, TokenResponse
+from app.schemas.auth import RegisterRequest, LoginRequest, ResetPasswordRequest, AdminForceResetPasswordRequest, TokenResponse
 from app.core.security import hash_password, verify_password, create_access_token, get_current_user, security_scheme
 from app.config import settings
 import re
@@ -19,16 +22,32 @@ def validate_password_strength(password: str) -> bool:
     return len(password) >= 8 and bool(re.search(r"[A-Za-z]", password)) and bool(re.search(r"\d", password))
 
 
+def normalize_email(email: str) -> str:
+    return email.strip().lower()
+
+
+def require_admin_reset_key(
+    x_admin_reset_key: Optional[str] = Header(default=None, alias="X-Admin-Reset-Key"),
+):
+    configured_key = (settings.ADMIN_RESET_KEY or "").strip()
+    if not configured_key:
+        raise HTTPException(status_code=503, detail="Admin reset endpoint is not configured")
+
+    if not x_admin_reset_key or not secrets.compare_digest(x_admin_reset_key, configured_key):
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+
 @router.post("/register", response_model=TokenResponse, status_code=201)
 def register(payload: RegisterRequest, db: Session = Depends(get_db)):
-    if not re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", payload.email):
+    email = normalize_email(payload.email)
+    if not re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", email):
         raise HTTPException(status_code=422, detail="Invalid email format")
-    if db.query(User).filter(User.email == payload.email).first():
+    if db.query(User).filter(func.lower(User.email) == email).first():
         raise HTTPException(status_code=409, detail="Email already registered")
     if not validate_password_strength(payload.password):
         raise HTTPException(status_code=422, detail="Password must be at least 8 characters and contain both letters and a number.")
 
-    user = User(name=payload.name, email=payload.email, password_hash=hash_password(payload.password))
+    user = User(name=payload.name, email=email, password_hash=hash_password(payload.password))
     db.add(user)
     db.commit()
     db.refresh(user)
@@ -39,12 +58,54 @@ def register(payload: RegisterRequest, db: Session = Depends(get_db)):
 
 @router.post("/login", response_model=TokenResponse)
 def login(payload: LoginRequest, db: Session = Depends(get_db)):
-    user = db.query(User).filter(User.email == payload.email).first()
+    email = normalize_email(payload.email)
+    user = db.query(User).filter(func.lower(User.email) == email).first()
     if not user or not verify_password(payload.password, user.password_hash):
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
     token = create_access_token({"sub": str(user.id)})
     return {"access_token": token, "token_type": "bearer"}
+
+
+@router.post("/reset-password")
+def reset_password(payload: ResetPasswordRequest, db: Session = Depends(get_db)):
+    email = normalize_email(payload.email)
+    user = db.query(User).filter(func.lower(User.email) == email).first()
+    if not user or not verify_password(payload.current_password, user.password_hash):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    if payload.current_password == payload.new_password:
+        raise HTTPException(status_code=422, detail="New password must be different from the current password")
+
+    if not validate_password_strength(payload.new_password):
+        raise HTTPException(status_code=422, detail="Password must be at least 8 characters and contain both letters and a number.")
+
+    user.password_hash = hash_password(payload.new_password)
+    db.commit()
+
+    return {"message": "Password updated successfully. Please sign in with your new password."}
+
+
+@router.post("/admin/force-reset-password")
+def admin_force_reset_password(
+    payload: AdminForceResetPasswordRequest,
+    _admin_ok: None = Depends(require_admin_reset_key),
+    db: Session = Depends(get_db),
+):
+    email = normalize_email(payload.email)
+    user = db.query(User).filter(func.lower(User.email) == email).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if not validate_password_strength(payload.new_password):
+        raise HTTPException(status_code=422, detail="Password must be at least 8 characters and contain both letters and a number.")
+
+    if verify_password(payload.new_password, user.password_hash):
+        raise HTTPException(status_code=422, detail="New password must be different from current password")
+
+    user.password_hash = hash_password(payload.new_password)
+    db.commit()
+    return {"message": "Password reset successfully"}
 
 
 @router.post("/logout")

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -125,6 +125,33 @@ def get_angles(session: SessionModel = Depends(verify_session_ownership)):
     # TODO: Query angle_frames and build response
     return {"session_id": session.id, "frames": []}
 
+@router.post("/{session_id}/retry", response_model=SessionResponse)
+def retry_session(
+    session: SessionModel = Depends(verify_session_ownership),
+    db: Session = Depends(get_db),
+):
+    if session.status != "failed":
+        raise HTTPException(
+            status_code=409,
+            detail="Only failed sessions can be retried",
+        )
+
+    session.status = "queued"
+    session.completed_at = None
+    db.commit()
+    db.refresh(session)
+
+    try:
+        process_video.delay(session.id)
+    except Exception as exc:
+        logging.warning("Celery dispatch failed on retry (is Redis running?): %s", exc)
+        session.status = "pending"
+        db.commit()
+        db.refresh(session)
+
+    return session
+
+
 @router.delete("/{session_id}", status_code=204)
 def delete_session(
     session: SessionModel = Depends(verify_session_ownership),

--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/0"
     CELERY_RESULT_BACKEND: str = "redis://localhost:6379/0"
     SECRET_KEY: str = "change-me-to-a-random-256-bit-secret"
+    ADMIN_RESET_KEY: str = ""
     UPLOAD_DIR: str = "app/uploads"
     OUTPUT_DIR: str = "output_videos"
     MODEL_DIR: str = "models"

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-router-dom": "^6.30.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -2983,6 +2984,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -13763,6 +13773,38 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -15593,6 +15635,23 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {

--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -1,251 +1,71 @@
-import { useState } from "react";
-import { LoginPage, LogoutButton } from "./pages/LoginPage";
-import { RegisterPage } from "./pages/RegisterPage";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { AuthProvider, useAuth } from "./AuthContext";
+import NavBar from "./NavBar";
+import LoginPage from "./pages/LoginPage";
+import RegisterPage from "./pages/RegisterPage";
+import DashboardPage from "./pages/DashboardPage";
 import { ShotsTable } from "./pages/ShotsTable";
+import SessionsPage from "./pages/SessionsPage";
+import UploadPage from "./pages/UploadPage";
 
-const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000/api";
+function ProtectedRoute({ children }) {
+  const { token } = useAuth();
+  return token ? children : <Navigate to="/login" replace />;
+}
 
-// ─── PLACEHOLDER DASHBOARD ────────────────────────────────────────────────────
-function Dashboard({
-  onLogout,
-  token,
-  onOpenShotsTable,
-  actionStatus,
-}) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = () => {
-    navigator.clipboard.writeText(token).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
-  };
-
+function AppShell() {
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        background: "#0a0a0f",
-        color: "#fff",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        fontFamily: "'DM Sans', sans-serif",
-        gap: "1rem",
-        padding: "2rem",
-      }}
-    >
-      <div
-        style={{
-          width: "48px",
-          height: "48px",
-          background: "linear-gradient(135deg, #ff6400, #ff9a00)",
-          borderRadius: "14px",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          fontSize: "24px",
-          marginBottom: "0.5rem",
-        }}
-      >
-        🏀
-      </div>
-      <h1 style={{ fontSize: "1.8rem", fontWeight: "700", margin: 0, letterSpacing: "-0.5px" }}>
-        Swish Vision
-      </h1>
-      <p style={{ color: "#555", margin: 0 }}>Dashboard coming soon</p>
-
-      {/* ── Bearer Token Box (for Postman testing) ── */}
-      <div
-        style={{
-          marginTop: "1.5rem",
-          background: "#13131a",
-          border: "1px solid #1e1e2e",
-          borderRadius: "14px",
-          padding: "1.25rem 1.5rem",
-          width: "100%",
-          maxWidth: "640px",
-        }}
-      >
-        <p style={{ color: "#888", fontSize: "0.72rem", letterSpacing: "1.5px", textTransform: "uppercase", margin: "0 0 0.6rem" }}>
-          Bearer Token (Postman)
-        </p>
-        <div style={{ display: "flex", gap: "0.75rem", alignItems: "flex-start" }}>
-          <code
-            style={{
-              flex: 1,
-              background: "#0d0d14",
-              border: "1px solid #1e1e2e",
-              borderRadius: "8px",
-              padding: "0.6rem 0.8rem",
-              fontSize: "0.72rem",
-              color: "#ff9a00",
-              wordBreak: "break-all",
-              lineHeight: "1.6",
-              display: "block",
-            }}
-          >
-            {token}
-          </code>
-          <button
-            onClick={handleCopy}
-            style={{
-              flexShrink: 0,
-              padding: "0.6rem 1rem",
-              background: copied ? "#22c55e" : "#1e1e2e",
-              border: "1px solid " + (copied ? "#22c55e" : "#333"),
-              borderRadius: "8px",
-              color: copied ? "#fff" : "#aaa",
-              fontSize: "0.8rem",
-              cursor: "pointer",
-              transition: "all 0.2s",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {copied ? "✓ Copied" : "Copy"}
-          </button>
-        </div>
-        <p style={{ color: "#444", fontSize: "0.72rem", marginTop: "0.6rem", marginBottom: 0 }}>
-          In Postman → Authorization tab → Bearer Token → paste above
-        </p>
-      </div>
-
-      <div
-        style={{
-          width: "100%",
-          maxWidth: "640px",
-          display: "grid",
-          gridTemplateColumns: "1fr",
-          gap: "0.75rem",
-        }}
-      >
-        <button
-          onClick={onOpenShotsTable}
-          style={{
-            padding: "0.85rem 1rem",
-            background: "linear-gradient(135deg, #ff6400, #ff9a00)",
-            border: "none",
-            borderRadius: "10px",
-            color: "#fff",
-            fontWeight: 700,
-            cursor: "pointer",
-          }}
-        >
-          Open Shots Table
-        </button>
-      </div>
-
-      {actionStatus ? (
-        <p style={{ margin: 0, color: "#aaa", fontSize: "0.9rem", maxWidth: "640px", textAlign: "center" }}>
-          {actionStatus}
-        </p>
-      ) : null}
-
-      <LogoutButton onLogout={onLogout} />
-    </div>
+    <>
+      <NavBar />
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute>
+              <DashboardPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/sessions"
+          element={
+            <ProtectedRoute>
+              <SessionsPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/shots"
+          element={
+            <ProtectedRoute>
+              <ShotsTable />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/upload"
+          element={
+            <ProtectedRoute>
+              <UploadPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route path="/" element={<Navigate to="/dashboard" replace />} />
+        <Route path="*" element={<Navigate to="/dashboard" replace />} />
+      </Routes>
+    </>
   );
 }
 
-// ─── APP ──────────────────────────────────────────────────────────────────────
 function App() {
-  // Lazy initialiser reads localStorage once on mount — keeps user logged in on refresh
-  const [token, setToken] = useState(() => localStorage.getItem("access_token"));
-  const [page, setPage] = useState("login"); // "login" | "register"
-  const [dashboardView, setDashboardView] = useState("dashboard"); // "dashboard" | "shots"
-  const [actionStatus, setActionStatus] = useState("");
-
-  const handleAuthError = () => {
-    localStorage.removeItem("access_token");
-    setToken(null);
-    setPage("login");
-    setDashboardView("dashboard");
-    setActionStatus("Session expired. Please log in again.");
-  };
-
-  const handleLoginSuccess = (data) => {
-    setToken(data.access_token);
-  };
-
-  const handleRegisterSuccess = (data) => {
-    if (data?.access_token) {
-      setToken(data.access_token);
-    } else {
-      // Registration succeeded but no token returned — send to login
-      setPage("login");
-    }
-  };
-
-  const handleLogout = () => {
-    setToken(null);
-    setPage("login");
-    setDashboardView("dashboard");
-    setActionStatus("");
-  };
-
-  const handleOpenShotsTable = async () => {
-    setActionStatus("");
-    setDashboardView("shots");
-  };
-
-  // ── Protected: token present ─────────────────────────────────────────────────
-  if (token) {
-    if (dashboardView === "shots") {
-      return (
-        <div
-          style={{
-            minHeight: "100vh",
-            background: "#0a0a0f",
-            color: "#fff",
-            fontFamily: "'DM Sans', sans-serif",
-            padding: "1rem",
-          }}
-        >
-          <button
-            onClick={() => setDashboardView("dashboard")}
-            style={{
-              marginBottom: "1rem",
-              padding: "0.65rem 0.9rem",
-              background: "#1e1e2e",
-              border: "1px solid #333",
-              borderRadius: "8px",
-              color: "#fff",
-              cursor: "pointer",
-            }}
-          >
-            Back to Dashboard
-          </button>
-          <ShotsTable token={token} onAuthError={handleAuthError} />
-        </div>
-      );
-    }
-
-    return (
-      <Dashboard
-        onLogout={handleLogout}
-        token={token}
-        onOpenShotsTable={handleOpenShotsTable}
-        actionStatus={actionStatus}
-      />
-    );
-  }
-
-  // ── Public: register ─────────────────────────────────────────────────────────
-  if (page === "register") {
-    return (
-      <RegisterPage
-        onRegisterSuccess={handleRegisterSuccess}
-        onGoToLogin={() => setPage("login")}
-      />
-    );
-  }
-
-  // ── Default: login (unauthenticated users always land here) ──────────────────
   return (
-    <LoginPage
-      onLoginSuccess={handleLoginSuccess}
-      onGoToRegister={() => setPage("register")}
-    />
+    <BrowserRouter>
+      <AuthProvider>
+        <AppShell />
+      </AuthProvider>
+    </BrowserRouter>
   );
 }
 

--- a/app/frontend/src/App.test.js
+++ b/app/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders login page heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/welcome back/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/app/frontend/src/AuthContext.js
+++ b/app/frontend/src/AuthContext.js
@@ -1,0 +1,46 @@
+import { createContext, useContext, useState, useCallback } from "react";
+
+const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000/api";
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(() => localStorage.getItem("access_token"));
+
+  const login = useCallback((accessToken) => {
+    localStorage.setItem("access_token", accessToken);
+    setToken(accessToken);
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      const t = localStorage.getItem("access_token");
+      if (t) {
+        await fetch(`${API_URL}/auth/logout`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${t}`,
+            "Content-Type": "application/json",
+          },
+        });
+      }
+    } catch (_) {
+      // Non-critical: clear locally regardless
+    } finally {
+      localStorage.removeItem("access_token");
+      setToken(null);
+    }
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used inside <AuthProvider>");
+  return ctx;
+}

--- a/app/frontend/src/NavBar.jsx
+++ b/app/frontend/src/NavBar.jsx
@@ -1,0 +1,107 @@
+import { Link, useNavigate, useLocation } from "react-router-dom";
+import { useAuth } from "./AuthContext";
+
+const NAV_LINKS = [
+  { to: "/sessions", label: "Sessions" },
+  { to: "/shots", label: "Shots" },
+  { to: "/upload", label: "Upload" },
+];
+
+export default function NavBar() {
+  const { token, logout } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  if (!token) return null;
+
+  const handleLogout = async () => {
+    await logout();
+    navigate("/login", { replace: true });
+  };
+
+  return (
+    <nav
+      style={{
+        background: "#13131a",
+        borderBottom: "1px solid #1e1e2e",
+        padding: "0 2rem",
+        height: "56px",
+        display: "flex",
+        alignItems: "center",
+        gap: "2rem",
+        fontFamily: "'DM Sans', sans-serif",
+        position: "sticky",
+        top: 0,
+        zIndex: 100,
+      }}
+    >
+      {/* Brand */}
+      <Link
+        to="/dashboard"
+        style={{ display: "flex", alignItems: "center", gap: "8px", textDecoration: "none", flexShrink: 0 }}
+      >
+        <span
+          style={{
+            width: "28px",
+            height: "28px",
+            background: "linear-gradient(135deg, #ff6400, #ff9a00)",
+            borderRadius: "8px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: "14px",
+          }}
+        >
+          🏀
+        </span>
+        <span style={{ fontSize: "1rem", fontWeight: 700, color: "#fff", letterSpacing: "-0.3px" }}>
+          Swish Vision
+        </span>
+      </Link>
+
+      <div style={{ flex: 1 }} />
+
+      {/* Nav links */}
+      {NAV_LINKS.map(({ to, label }) => {
+        const active = location.pathname === to;
+        return (
+          <Link
+            key={to}
+            to={to}
+            style={{
+              color: active ? "#fff" : "#666",
+              fontSize: "0.875rem",
+              fontWeight: 600,
+              textDecoration: "none",
+              borderBottom: active ? "2px solid #ff6400" : "2px solid transparent",
+              paddingBottom: "2px",
+              transition: "color 0.15s",
+            }}
+          >
+            {label}
+          </Link>
+        );
+      })}
+
+      {/* Logout */}
+      <button
+        onClick={handleLogout}
+        style={{
+          padding: "0.45rem 1.1rem",
+          background: "transparent",
+          border: "1px solid #333",
+          borderRadius: "8px",
+          color: "#666",
+          fontSize: "0.8rem",
+          cursor: "pointer",
+          fontFamily: "inherit",
+          transition: "all 0.15s",
+        }}
+        onMouseEnter={(e) => { e.currentTarget.style.borderColor = "#ff6400"; e.currentTarget.style.color = "#ff6400"; }}
+        onMouseLeave={(e) => { e.currentTarget.style.borderColor = "#333"; e.currentTarget.style.color = "#666"; }}
+      >
+        Log Out
+      </button>
+    </nav>
+  );
+}

--- a/app/frontend/src/pages/DashboardPage.jsx
+++ b/app/frontend/src/pages/DashboardPage.jsx
@@ -1,0 +1,186 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "../AuthContext";
+
+export default function DashboardPage() {
+  const { token } = useAuth();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(token).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: "calc(100vh - 56px)",
+        background: "#0a0a0f",
+        color: "#fff",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily: "'DM Sans', sans-serif",
+        gap: "1rem",
+        padding: "2rem",
+      }}
+    >
+      {/* Logo */}
+      <div
+        style={{
+          width: "52px",
+          height: "52px",
+          background: "linear-gradient(135deg, #ff6400, #ff9a00)",
+          borderRadius: "14px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: "26px",
+          marginBottom: "0.25rem",
+        }}
+      >
+        🏀
+      </div>
+
+      <h1 style={{ fontSize: "1.8rem", fontWeight: 700, margin: 0, letterSpacing: "-0.5px" }}>
+        Swish Vision
+      </h1>
+      <p style={{ color: "#555", margin: 0, fontSize: "0.9rem" }}>
+        Use the navigation above or the shortcuts below.
+      </p>
+
+      {/* Bearer Token Box */}
+      <div
+        style={{
+          marginTop: "1.5rem",
+          background: "#13131a",
+          border: "1px solid #1e1e2e",
+          borderRadius: "14px",
+          padding: "1.25rem 1.5rem",
+          width: "100%",
+          maxWidth: "640px",
+        }}
+      >
+        <p
+          style={{
+            color: "#555",
+            fontSize: "0.7rem",
+            letterSpacing: "1.5px",
+            textTransform: "uppercase",
+            margin: "0 0 0.6rem",
+          }}
+        >
+          Bearer Token (Postman)
+        </p>
+        <div style={{ display: "flex", gap: "0.75rem", alignItems: "flex-start" }}>
+          <code
+            style={{
+              flex: 1,
+              background: "#0d0d14",
+              border: "1px solid #1e1e2e",
+              borderRadius: "8px",
+              padding: "0.6rem 0.8rem",
+              fontSize: "0.7rem",
+              color: "#ff9a00",
+              wordBreak: "break-all",
+              lineHeight: "1.6",
+              display: "block",
+            }}
+          >
+            {token}
+          </code>
+          <button
+            onClick={handleCopy}
+            style={{
+              flexShrink: 0,
+              padding: "0.6rem 1rem",
+              background: copied ? "#22c55e" : "#1e1e2e",
+              border: `1px solid ${copied ? "#22c55e" : "#333"}`,
+              borderRadius: "8px",
+              color: copied ? "#fff" : "#aaa",
+              fontSize: "0.8rem",
+              cursor: "pointer",
+              transition: "all 0.2s",
+              whiteSpace: "nowrap",
+              fontFamily: "inherit",
+            }}
+          >
+            {copied ? "✓ Copied" : "Copy"}
+          </button>
+        </div>
+        <p style={{ color: "#333", fontSize: "0.7rem", marginTop: "0.6rem", marginBottom: 0 }}>
+          Postman → Authorization → Bearer Token → paste above
+        </p>
+      </div>
+
+      {/* Quick-nav buttons */}
+      <div
+        style={{
+          width: "100%",
+          maxWidth: "640px",
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr",
+          gap: "0.75rem",
+        }}
+      >
+        <Link to="/shots" style={{ textDecoration: "none" }}>
+          <button
+            style={{
+              width: "100%",
+              padding: "0.9rem 1rem",
+              background: "linear-gradient(135deg, #ff6400, #ff9a00)",
+              border: "none",
+              borderRadius: "10px",
+              color: "#fff",
+              fontWeight: 700,
+              cursor: "pointer",
+              fontSize: "0.95rem",
+              fontFamily: "inherit",
+            }}
+          >
+            Shots
+          </button>
+        </Link>
+        <Link to="/sessions" style={{ textDecoration: "none" }}>
+          <button
+            style={{
+              width: "100%",
+              padding: "0.9rem 1rem",
+              background: "#1e1e2e",
+              border: "1px solid #333",
+              borderRadius: "10px",
+              color: "#fff",
+              fontWeight: 700,
+              cursor: "pointer",
+              fontSize: "0.95rem",
+              fontFamily: "inherit",
+            }}
+          >
+            Sessions
+          </button>
+        </Link>
+        <Link to="/upload" style={{ textDecoration: "none" }}>
+          <button
+            style={{
+              width: "100%",
+              padding: "0.9rem 1rem",
+              background: "#1e1e2e",
+              border: "1px solid #333",
+              borderRadius: "10px",
+              color: "#fff",
+              fontWeight: 700,
+              cursor: "pointer",
+              fontSize: "0.95rem",
+              fontFamily: "inherit",
+            }}
+          >
+            Upload
+          </button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/pages/LoginPage.jsx
+++ b/app/frontend/src/pages/LoginPage.jsx
@@ -1,4 +1,6 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../AuthContext";
 
 // ─── CONFIG ───────────────────────────────────────────────────────────────────
 // Replace with your actual API base URL (from .env: REACT_APP_API_URL)
@@ -137,10 +139,14 @@ const styles = {
 };
 
 // ─── LOGIN PAGE ───────────────────────────────────────────────────────────────
-export function LoginPage({ onLoginSuccess, onGoToRegister }) {
-  const [form, setForm] = useState({ email: "", password: "" });
+export function LoginPage() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [mode, setMode] = useState("login"); // login | reset
+  const [form, setForm] = useState({ email: "", password: "", newPassword: "", confirmNewPassword: "" });
   const [errors, setErrors] = useState({});
   const [apiError, setApiError] = useState("");
+  const [apiSuccess, setApiSuccess] = useState("");
   const [loading, setLoading] = useState(false);
 
   const validate = () => {
@@ -148,6 +154,17 @@ export function LoginPage({ onLoginSuccess, onGoToRegister }) {
     if (!form.email.trim()) e.email = "Email is required";
     else if (!/\S+@\S+\.\S+/.test(form.email)) e.email = "Enter a valid email";
     if (!form.password) e.password = "Password is required";
+    if (mode === "reset") {
+      if (!form.newPassword) e.newPassword = "New password is required";
+      else if (!(form.newPassword.length >= 8 && /[A-Za-z]/.test(form.newPassword) && /\d/.test(form.newPassword))) {
+        e.newPassword = "Password must be at least 8 chars with letters and numbers";
+      }
+      if (!form.confirmNewPassword) e.confirmNewPassword = "Please confirm your new password";
+      else if (form.newPassword !== form.confirmNewPassword) e.confirmNewPassword = "Passwords do not match";
+      if (form.newPassword && form.password && form.newPassword === form.password) {
+        e.newPassword = "New password must be different from current password";
+      }
+    }
     return e;
   };
 
@@ -155,37 +172,67 @@ export function LoginPage({ onLoginSuccess, onGoToRegister }) {
     setForm({ ...form, [e.target.name]: e.target.value });
     setErrors({ ...errors, [e.target.name]: "" });
     setApiError("");
+    setApiSuccess("");
   };
 
   const handleSubmit = async () => {
     const e = validate();
     if (Object.keys(e).length) return setErrors(e);
 
+    const normalizedEmail = form.email.trim().toLowerCase();
+
     setLoading(true);
     setApiError("");
+    setApiSuccess("");
 
     try {
-      const res = await fetch(`${API_URL}/auth/login`, {
+      if (mode === "login") {
+        const res = await fetch(`${API_URL}/auth/login`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: normalizedEmail, password: form.password }),
+        });
 
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: form.email, password: form.password }),
-      });
+        const data = await res.json();
 
-      const data = await res.json();
+        if (!res.ok) {
+          if (res.status === 401) setApiError("Invalid email or password.");
+          else if (res.status === 403) setApiError("Your account has been suspended.");
+          else if (res.status === 429) setApiError("Too many attempts. Please wait a moment.");
+          else setApiError(data?.detail || "Something went wrong. Please try again.");
+          return;
+        }
 
-      if (!res.ok) {
-        // Handle specific backend error messages
-        if (res.status === 401) setApiError("Invalid email or password.");
-        else if (res.status === 403) setApiError("Your account has been suspended.");
-        else if (res.status === 429) setApiError("Too many attempts. Please wait a moment.");
-        else setApiError(data?.detail || "Something went wrong. Please try again.");
+        login(data.access_token);
+        navigate("/dashboard", { replace: true });
         return;
       }
 
-      // Store JWT token
-      localStorage.setItem("access_token", data.access_token);
-      if (onLoginSuccess) onLoginSuccess(data);
+      const res = await fetch(`${API_URL}/auth/reset-password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: normalizedEmail,
+          current_password: form.password,
+          new_password: form.newPassword,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        if (res.status === 401) setApiError("Current email/password is incorrect.");
+        else setApiError(data?.detail || "Could not update password. Please try again.");
+        return;
+      }
+
+      setApiSuccess(data?.message || "Password updated. Sign in with your new password.");
+      setMode("login");
+      setForm((prev) => ({
+        ...prev,
+        password: "",
+        newPassword: "",
+        confirmNewPassword: "",
+      }));
 
     } catch (err) {
       setApiError("Cannot connect to server. Check your connection.");
@@ -206,11 +253,30 @@ export function LoginPage({ onLoginSuccess, onGoToRegister }) {
           </div>
         </div>
 
-        <h1 style={styles.heading}>Welcome back</h1>
-        <p style={styles.subheading}>Sign in to your account to continue</p>
+        <h1 style={styles.heading}>{mode === "login" ? "Welcome back" : "Change password"}</h1>
+        <p style={styles.subheading}>
+          {mode === "login"
+            ? "Sign in to your account to continue"
+            : "Use your current login details, then set a new password"}
+        </p>
 
         {/* API Error Banner */}
         {apiError && <div style={styles.alertError}>⚠ {apiError}</div>}
+        {apiSuccess ? (
+          <div
+            style={{
+              background: "rgba(34, 197, 94, 0.12)",
+              border: "1px solid rgba(34, 197, 94, 0.35)",
+              borderRadius: "10px",
+              padding: "0.75rem 1rem",
+              color: "#86efac",
+              fontSize: "0.875rem",
+              marginBottom: "1.2rem",
+            }}
+          >
+            {apiSuccess}
+          </div>
+        ) : null}
 
         {/* Email */}
         <div style={styles.field}>
@@ -246,14 +312,76 @@ export function LoginPage({ onLoginSuccess, onGoToRegister }) {
           {errors.password && <p style={styles.errorText}>{errors.password}</p>}
         </div>
 
+        {mode === "reset" ? (
+          <>
+            <div style={styles.field}>
+              <label htmlFor="newPassword" style={styles.label}>New Password</label>
+              <input
+                id="newPassword"
+                style={{ ...styles.input, ...(errors.newPassword ? styles.inputError : {}) }}
+                type="password"
+                name="newPassword"
+                placeholder="New password"
+                value={form.newPassword}
+                onChange={handleChange}
+                onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+              />
+              {errors.newPassword && <p style={styles.errorText}>{errors.newPassword}</p>}
+            </div>
+
+            <div style={styles.field}>
+              <label htmlFor="confirmNewPassword" style={styles.label}>Confirm New Password</label>
+              <input
+                id="confirmNewPassword"
+                style={{ ...styles.input, ...(errors.confirmNewPassword ? styles.inputError : {}) }}
+                type="password"
+                name="confirmNewPassword"
+                placeholder="Confirm new password"
+                value={form.confirmNewPassword}
+                onChange={handleChange}
+                onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+              />
+              {errors.confirmNewPassword && <p style={styles.errorText}>{errors.confirmNewPassword}</p>}
+            </div>
+          </>
+        ) : null}
+
         {/* Submit */}
         <button
           style={{ ...styles.button, ...(loading ? styles.buttonDisabled : {}) }}
           onClick={handleSubmit}
           disabled={loading}
         >
-          {loading ? "Signing in..." : "Sign In"}
+          {loading ? (mode === "login" ? "Signing in..." : "Updating password...") : (mode === "login" ? "Sign In" : "Update Password")}
         </button>
+
+        <div style={{ ...styles.footer, marginTop: "0.75rem" }}>
+          <button
+            type="button"
+            style={{
+              ...styles.link,
+              background: "none",
+              border: "none",
+              padding: 0,
+              cursor: "pointer",
+              font: "inherit",
+            }}
+            onClick={() => {
+              setMode(mode === "login" ? "reset" : "login");
+              setErrors({});
+              setApiError("");
+              setApiSuccess("");
+              setForm((prev) => ({
+                ...prev,
+                password: "",
+                newPassword: "",
+                confirmNewPassword: "",
+              }));
+            }}
+          >
+            {mode === "login" ? "Forgot password? Change it here" : "Back to sign in"}
+          </button>
+        </div>
 
         <div style={styles.footer}>
           Don't have an account?{" "}
@@ -267,7 +395,7 @@ export function LoginPage({ onLoginSuccess, onGoToRegister }) {
               cursor: "pointer",
               font: "inherit",
             }}
-            onClick={() => { if (onGoToRegister) onGoToRegister(); }}
+            onClick={() => navigate("/register")}
           >
             Register
           </button>
@@ -280,36 +408,18 @@ export function LoginPage({ onLoginSuccess, onGoToRegister }) {
 // ─── LOGOUT BUTTON ────────────────────────────────────────────────────────────
 // Drop this anywhere in your app (navbar, dashboard, etc.)
 export function LogoutButton({ onLogout }) {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
   const handleLogout = async () => {
     setLoading(true);
     setError("");
-
-    try {
-      const token = localStorage.getItem("access_token");
-
-      // Optional: tell the backend to invalidate the token
-      if (token) {
-        await fetch(`${API_URL}/auth/logout`, {
-
-          method: "POST",
-          headers: {
-            "Authorization": `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
-        });
-        // We don't block on the response — clear locally regardless
-      }
-    } catch (err) {
-      // Non-critical: still log out locally even if server call fails
-      setError("Server error, but you've been logged out locally.");
-    } finally {
-      localStorage.removeItem("access_token");
-      setLoading(false);
-      if (onLogout) onLogout();
-    }
+    await logout();
+    setLoading(false);
+    if (onLogout) onLogout();
+    navigate("/login", { replace: true });
   };
 
   return (

--- a/app/frontend/src/pages/RegisterPage.jsx
+++ b/app/frontend/src/pages/RegisterPage.jsx
@@ -1,4 +1,6 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../AuthContext";
 
 const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000/api";
 
@@ -179,7 +181,9 @@ function getStrength(password) {
   return { score, label: labels[score] || "", color: colors[score] || "#1e1e2e" };
 }
 
-export function RegisterPage({ onRegisterSuccess, onGoToLogin }) {
+export function RegisterPage() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
   const [form, setForm] = useState({
     firstName: "",
     lastName: "",
@@ -284,9 +288,11 @@ export function RegisterPage({ onRegisterSuccess, onGoToLogin }) {
       }
 
       if (data?.access_token) {
-        localStorage.setItem("access_token", data.access_token);
+        login(data.access_token);
+        navigate("/dashboard", { replace: true });
+      } else {
+        navigate("/login");
       }
-      if (onRegisterSuccess) onRegisterSuccess(data);
 
     } catch (err) {
       setApiError("Cannot connect to server. Check your connection.");
@@ -427,7 +433,7 @@ export function RegisterPage({ onRegisterSuccess, onGoToLogin }) {
           <button
             type="button"
             style={styles.link}
-            onClick={() => { if (onGoToLogin) onGoToLogin(); }}
+            onClick={() => navigate("/login")}
           >
             Sign in
           </button>

--- a/app/frontend/src/pages/SessionsPage.jsx
+++ b/app/frontend/src/pages/SessionsPage.jsx
@@ -1,0 +1,178 @@
+import { useEffect, useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../AuthContext";
+
+const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000/api";
+
+async function retrySession(sessionId, setSessions, token, setError) {
+  const res = await fetch(`${API_URL}/sessions/${sessionId}/retry`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (res.ok) {
+    const updated = await res.json();
+    setSessions((prev) => prev.map((s) => (s.id === sessionId ? updated : s)));
+    return;
+  }
+
+  const body = await res.json().catch(() => ({}));
+  setError(body.detail || "Failed to retry session.");
+}
+
+async function deleteSession(sessionId, setSessions, token, setError) {
+  if (!window.confirm("Delete this session? This cannot be undone.")) return;
+
+  const res = await fetch(`${API_URL}/sessions/${sessionId}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (res.status === 204) {
+    setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+    return;
+  }
+
+  if (res.status === 409) {
+    setError("Session is currently processing. Please wait until it completes.");
+    return;
+  }
+
+  const body = await res.json().catch(() => ({}));
+  setError(body.detail || "Failed to delete session.");
+}
+
+export default function SessionsPage() {
+  const { token, logout } = useAuth();
+  const navigate = useNavigate();
+  const [sessions, setSessions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const fetchSessions = useCallback(async () => {
+    setError("");
+    try {
+      const res = await fetch(`${API_URL}/sessions/`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (res.status === 401) {
+        await logout();
+        navigate("/login", { replace: true });
+        return;
+      }
+
+      const body = await res.json().catch(() => []);
+      if (!res.ok) {
+        setError(body?.detail || "Failed to load sessions.");
+        return;
+      }
+
+      setSessions(Array.isArray(body) ? body : []);
+    } catch (_err) {
+      setError("Failed to load sessions.");
+    } finally {
+      setLoading(false);
+    }
+  }, [token, logout, navigate]);
+
+  useEffect(() => {
+    fetchSessions();
+  }, [fetchSessions]);
+
+  // Poll every 5 s while any session is queued or processing
+  useEffect(() => {
+    const hasInflight = sessions.some(
+      (s) => s.status === "queued" || s.status === "processing"
+    );
+    if (!hasInflight) return;
+    const timer = setInterval(fetchSessions, 5000);
+    return () => clearInterval(timer);
+  }, [sessions, fetchSessions]);
+
+  if (loading) return <div>Loading sessions...</div>;
+
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h2>My Sessions</h2>
+      {error ? (
+        <div
+          style={{
+            marginBottom: "1rem",
+            padding: "0.8rem 1rem",
+            borderRadius: "10px",
+            border: "1px solid rgba(239,68,68,0.3)",
+            background: "rgba(239,68,68,0.12)",
+            color: "#ff8a8a",
+          }}
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {sessions.length === 0 ? (
+        <p>No sessions found.</p>
+      ) : (
+        <table
+          style={{
+            width: "100%",
+            borderCollapse: "collapse",
+            border: "1px solid #1e1e2e",
+          }}
+        >
+          <thead>
+            <tr style={{ background: "#13131a", borderBottom: "1px solid #1e1e2e" }}>
+              <th style={{ padding: "0.75rem", textAlign: "left" }}>Session</th>
+              <th style={{ padding: "0.75rem", textAlign: "left" }}>File</th>
+              <th style={{ padding: "0.75rem", textAlign: "left" }}>Status</th>
+              <th style={{ padding: "0.75rem", textAlign: "left" }}>Created</th>
+              <th style={{ padding: "0.75rem", textAlign: "left" }}>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sessions.map((session) => (
+              <tr key={session.id} style={{ borderBottom: "1px solid #1e1e2e" }}>
+                <td style={{ padding: "0.75rem" }}>#{session.id}</td>
+                <td style={{ padding: "0.75rem" }}>{session.original_filename}</td>
+                <td style={{ padding: "0.75rem" }}>{session.status}</td>
+                <td style={{ padding: "0.75rem" }}>
+                  {new Date(session.created_at).toLocaleString()}
+                </td>
+                <td style={{ padding: "0.75rem", display: "flex", gap: "0.5rem", alignItems: "center" }}>
+                  {session.status === "failed" && (
+                    <button
+                      onClick={() => retrySession(session.id, setSessions, token, setError)}
+                      style={{
+                        padding: "0.5rem 0.8rem",
+                        borderRadius: "8px",
+                        border: "1px solid #1f4a5f",
+                        color: "#7dd3fc",
+                        background: "#0c2233",
+                        cursor: "pointer",
+                      }}
+                    >
+                      Retry
+                    </button>
+                  )}
+                  <button
+                    onClick={() => deleteSession(session.id, setSessions, token, setError)}
+                    style={{
+                      padding: "0.5rem 0.8rem",
+                      borderRadius: "8px",
+                      border: "1px solid #5f1f1f",
+                      color: "#ffb1b1",
+                      background: "#2a1111",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/pages/ShotsTable.jsx
+++ b/app/frontend/src/pages/ShotsTable.jsx
@@ -1,8 +1,12 @@
 import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../AuthContext";
 
 const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000/api";
 
-export function ShotsTable({ token, onAuthError }) {
+export function ShotsTable() {
+  const { token } = useAuth();
+  const navigate = useNavigate();
   const [sessions, setSessions] = useState([]);
   const [selectedSessionId, setSelectedSessionId] = useState("");
   const [shots, setShotsData] = useState([]);
@@ -20,7 +24,7 @@ export function ShotsTable({ token, onAuthError }) {
         const data = await response.json();
 
         if (response.status === 401) {
-          if (onAuthError) onAuthError();
+          navigate("/login", { replace: true });
           return;
         }
 
@@ -35,7 +39,7 @@ export function ShotsTable({ token, onAuthError }) {
     };
 
     fetchSessions();
-  }, [token, onAuthError]);
+  }, [token, navigate]);
 
   useEffect(() => {
     if (!selectedSessionId) {
@@ -53,7 +57,7 @@ export function ShotsTable({ token, onAuthError }) {
         });
 
         if (response.status === 401) {
-          if (onAuthError) onAuthError();
+          navigate("/login", { replace: true });
           return;
         }
         
@@ -73,7 +77,7 @@ export function ShotsTable({ token, onAuthError }) {
     };
 
     fetchShots();
-  }, [selectedSessionId, token, onAuthError]);
+  }, [selectedSessionId, token, navigate]);
 
   if (loadingSessions) return <div>Loading sessions...</div>;
   if (error) return <div>Error: {error}</div>;

--- a/app/frontend/src/pages/UploadPage.jsx
+++ b/app/frontend/src/pages/UploadPage.jsx
@@ -1,16 +1,18 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../AuthContext';
 
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000/api';
 
 export default function UploadPage() {
+  const { token } = useAuth();
+  const navigate = useNavigate();
   const [file, setFile] = useState(null);
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState('');
   const [status, setStatus] = useState('idle'); // idle | uploading | queued | failed
   const inputRef = useRef();
   const xhrRef = useRef(null);
-  const navigate = useNavigate();
 
   useEffect(() => {
     return () => { xhrRef.current?.abort(); };
@@ -55,7 +57,6 @@ export default function UploadPage() {
     setProgress(0);
     setError('');
 
-    const token = localStorage.getItem('access_token');
     if (!token) {
       setError('You must be logged in to upload');
       setStatus('failed');
@@ -75,10 +76,9 @@ export default function UploadPage() {
 
     xhr.onload = () => {
       if (xhr.status === 201) {
-        const data = JSON.parse(xhr.responseText);
+        JSON.parse(xhr.responseText);
         setStatus('queued');
         setProgress(100);
-        navigate(`/sessions/${data.id}`);
       } else if (xhr.status === 409) {
         setError('Cannot upload while another session is processing');
         setStatus('failed');
@@ -100,7 +100,7 @@ export default function UploadPage() {
 
     xhr.onabort = () => {};
 
-    xhr.open('POST', `${API_URL}/api/sessions/upload`);
+    xhr.open('POST', `${API_URL}/sessions/upload`);
     xhr.setRequestHeader('Authorization', `Bearer ${token}`);
     setStatus('uploading');
     xhr.send(fd);

--- a/app/migrations/versions/20260428_add_shot_event_angles.py
+++ b/app/migrations/versions/20260428_add_shot_event_angles.py
@@ -1,0 +1,32 @@
+"""add elbow_angle and shoulder_angle to shot_events
+
+Revision ID: 20260428_add_shot_event_angles
+Revises: 20260405_initial_schema
+Create Date: 2026-04-28 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20260428_add_shot_event_angles"
+down_revision = "20260405_initial_schema"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_cols = [c["name"] for c in inspector.get_columns("shot_events")]
+
+    if "elbow_angle" not in existing_cols:
+        op.add_column("shot_events", sa.Column("elbow_angle", sa.Float(), nullable=True))
+
+    if "shoulder_angle" not in existing_cols:
+        op.add_column("shot_events", sa.Column("shoulder_angle", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("shot_events", "shoulder_angle")
+    op.drop_column("shot_events", "elbow_angle")

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -12,6 +12,17 @@ class LoginRequest(BaseModel):
     password: str
 
 
+class ResetPasswordRequest(BaseModel):
+    email: str
+    current_password: str
+    new_password: str
+
+
+class AdminForceResetPasswordRequest(BaseModel):
+    email: str
+    new_password: str
+
+
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str

--- a/app/tasks/pipeline_task.py
+++ b/app/tasks/pipeline_task.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 import os
 import shutil
+from sqlalchemy import inspect, text
 from celery import Celery
 from celery.utils.log import get_task_logger
 
@@ -25,6 +26,11 @@ celery_app.conf.update(
 )
 
 logger = get_task_logger(__name__)
+
+
+def _get_table_columns(db, table_name: str) -> set[str]:
+    bind = db.get_bind()
+    return {column["name"] for column in inspect(bind).get_columns(table_name)}
 
 
 def _normalize_shot_result(result) -> str:
@@ -55,17 +61,18 @@ def _cleanup_transient_files():
                 logger.warning("Could not delete transient file %s: %s", fname, e)
 
 
-@celery_app.task(bind=True, max_retries=0)
+@celery_app.task(bind=True, max_retries=2, autoretry_for=(Exception,), retry_backoff=True)
 def process_video(self, session_id: int):
     """Celery task wrapping the CV pipeline for a given session."""
     from app.database import SessionLocal
     from app.models.session import SessionModel
     from app.models.angle_frame import AngleFrame
-    from app.models.shot_event import ShotEvent
-    from app.models.report import Report
+    from app.tasks.report_parser import parse_and_persist
 
     db = SessionLocal()
     session = None
+    input_path = None
+    copied_input_file = False
     try:
         session = db.query(SessionModel).filter(SessionModel.id == session_id).first()
         if not session:
@@ -75,11 +82,25 @@ def process_video(self, session_id: int):
         session.status = "processing"
         db.commit()
 
-        # Copy uploaded video to input_videos/ for pipeline
-        input_dir = "input_videos"
+        source_upload_path = os.path.abspath(session.upload_path or "")
+        if not source_upload_path or not os.path.exists(source_upload_path):
+            raise FileNotFoundError(f"Upload file missing: {session.upload_path}")
+
+        # Copy uploaded video into input_videos only when source is outside input_videos.
+        # This avoids deleting the original upload when handling failures.
+        input_dir = os.path.abspath("input_videos")
         os.makedirs(input_dir, exist_ok=True)
-        input_path = os.path.join(input_dir, os.path.basename(session.upload_path))
-        shutil.copy2(session.upload_path, input_path)
+        source_dir = os.path.dirname(source_upload_path)
+
+        if os.path.normcase(source_dir) == os.path.normcase(input_dir):
+            input_path = source_upload_path
+            logger.debug("Using upload in input_videos directly for session %s: %s", session_id, input_path)
+        else:
+            input_filename = f"session_{session_id}_{os.path.basename(source_upload_path)}"
+            input_path = os.path.join(input_dir, input_filename)
+            shutil.copy2(source_upload_path, input_path)
+            copied_input_file = True
+            logger.debug("Copied upload for processing for session %s: %s -> %s", session_id, source_upload_path, input_path)
 
         # Run the CV pipeline
         from main import run_pipeline
@@ -99,10 +120,6 @@ def process_video(self, session_id: int):
         shot_starts = pipeline_data.get("shot_strt", [])
         shot_ends = pipeline_data.get("shot_end", [])
         order_shots = pipeline_data.get("order_shots", [])
-        total_shots = pipeline_data.get("total_shots", 0)
-        made_shots = pipeline_data.get("made_shots", 0)
-        missed_shots = pipeline_data.get("missed_shots", 0)
-
         logger.debug(
             "Counts for session %s: shot_angles=%s shot_starts=%s shot_ends=%s order_shots=%s",
             session_id,
@@ -110,13 +127,6 @@ def process_video(self, session_id: int):
             len(shot_starts),
             len(shot_ends),
             len(order_shots),
-        )
-        logger.debug(
-            "Summary for session %s: total_shots=%s made_shots=%s missed_shots=%s",
-            session_id,
-            total_shots,
-            made_shots,
-            missed_shots,
         )
         
         # Bulk insert AngleFrame records
@@ -147,60 +157,65 @@ def process_video(self, session_id: int):
         else:
             logger.warning("No shot_angles or shot_starts available for AngleFrame insert (session %s)", session_id)
 
-        # Insert Report record
-        report_text = ""
-        if os.path.exists(report_path):
-            try:
-                with open(report_path, "r", encoding="utf-8") as f:
-                    report_text = f.read()
-            except Exception as e:
-                logger.warning("Could not read report file %s: %s", report_path, e)
-        
-        report = Report(
-            session_id=session_id,
-            raw_text=report_text,
-            total_shots=total_shots,
-            makes=made_shots,
-            misses=missed_shots,
-        )
-        db.add(report)
+        parse_and_persist(session_id=session_id, report_path=report_path, db=db)
+
+        # Keep parser as source-of-truth for rows, then enrich with pipeline-only fields.
+        shot_event_columns = _get_table_columns(db, "shot_events")
+        if not (len(shot_starts) == len(shot_ends) == len(shot_angles) == len(order_shots)):
+            logger.warning(
+                "ShotEvent enrichment length mismatch for session %s: shot_starts=%s shot_ends=%s shot_angles=%s order_shots=%s. Using shortest length.",
+                session_id,
+                len(shot_starts),
+                len(shot_ends),
+                len(shot_angles),
+                len(order_shots),
+            )
+
+        updates_applied = 0
+        for shot_num, start_frame, release_frame, angles, result in zip(
+            range(1, min(len(shot_starts), len(shot_ends), len(shot_angles), len(order_shots)) + 1),
+            shot_starts,
+            shot_ends,
+            shot_angles,
+            order_shots,
+        ):
+            elbow_angle, shoulder_angle = angles
+            set_clauses = []
+            params = {
+                "session_id": session_id,
+                "shot_number": shot_num,
+            }
+
+            if "result" in shot_event_columns:
+                set_clauses.append("result = :result")
+                params["result"] = _normalize_shot_result(result)
+            if "start_frame" in shot_event_columns:
+                set_clauses.append("start_frame = :start_frame")
+                params["start_frame"] = int(start_frame)
+            if "end_frame" in shot_event_columns:
+                set_clauses.append("end_frame = :end_frame")
+                params["end_frame"] = int(release_frame)
+            if "elbow_angle" in shot_event_columns:
+                set_clauses.append("elbow_angle = :elbow_angle")
+                params["elbow_angle"] = float(elbow_angle) if isinstance(elbow_angle, (int, float)) else None
+            if "shoulder_angle" in shot_event_columns:
+                set_clauses.append("shoulder_angle = :shoulder_angle")
+                params["shoulder_angle"] = float(shoulder_angle) if shoulder_angle is not None else None
+
+            if not set_clauses:
+                continue
+
+            db.execute(
+                text(
+                    f"UPDATE shot_events SET {', '.join(set_clauses)} "
+                    "WHERE session_id = :session_id AND shot_number = :shot_number"
+                ),
+                params,
+            )
+            updates_applied += 1
+
         db.commit()
-        logger.info("Inserted Report record for session %s", session_id)
-
-        # Bulk insert ShotEvent records
-        shot_events_list = []
-        
-        if shot_starts and shot_ends and shot_angles and order_shots:
-            if not (len(shot_starts) == len(shot_ends) == len(shot_angles) == len(order_shots)):
-                logger.warning(
-                    "ShotEvent length mismatch for session %s: shot_starts=%s shot_ends=%s shot_angles=%s order_shots=%s. Using shortest length.",
-                    session_id,
-                    len(shot_starts),
-                    len(shot_ends),
-                    len(shot_angles),
-                    len(order_shots),
-                )
-
-            for shot_num, (start_frame, release_frame, (elbow_angle, shoulder_angle), result) in enumerate(
-                zip(shot_starts, shot_ends, shot_angles, order_shots), 1):
-
-                
-                shot_events_list.append({
-                    "session_id": session_id,
-                    "shot_number": shot_num,
-                    "result": _normalize_shot_result(result),
-                    "start_frame": int(start_frame),
-                    "end_frame": int(release_frame),
-                    "elbow_angle": float(elbow_angle) if isinstance(elbow_angle, (int, float)) else None,
-                    "shoulder_angle": float(shoulder_angle) if shoulder_angle is not None else None,
-                })
-            
-            if shot_events_list:
-                db.bulk_insert_mappings(ShotEvent, shot_events_list)
-                db.commit()
-                logger.info("Inserted %s ShotEvent records for session %s", len(shot_events_list), session_id)
-        else:
-            logger.warning("Missing data for ShotEvent insert (session %s)", session_id)
+        logger.info("Enriched %s ShotEvent records for session %s", updates_applied, session_id)
 
         session.output_path = output_path
         session.report_path = report_path
@@ -211,11 +226,12 @@ def process_video(self, session_id: int):
 
     except Exception:
         logger.exception("Exception during video processing for session %s", session_id)
+        db.rollback()
         if session is not None:
             session.status = "failed"
             db.commit()
 
-        if 'input_path' in locals() and os.path.exists(input_path):
+        if copied_input_file and input_path and os.path.exists(input_path):
             logger.debug("Removing copied input file after failure: %s", input_path)
             os.remove(input_path)
 

--- a/app/tasks/report_parser.py
+++ b/app/tasks/report_parser.py
@@ -1,0 +1,146 @@
+import logging
+import re
+from sqlalchemy import inspect
+
+from app.models.report import Report
+from app.models.shot_event import ShotEvent
+
+
+logger = logging.getLogger(__name__)
+
+
+def parse_and_persist(session_id: int, report_path: str, db):
+    """Parse HumanTracksDrawer report text and persist Report + ShotEvent rows.
+
+    The parser supports both:
+    - legacy free-form report lines (e.g., "Shot 1: made, release=48.3, elbow=92.1")
+    - current HumanTracksDrawer.analysis() blocks ("GOOD FORM" / "shot N" + "NEEDS WORK")
+    """
+    with open(report_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    shot_events = _parse_shot_lines(content)
+    if not shot_events:
+        shot_events = _parse_analysis_blocks(content)
+
+    makes = sum(1 for event in shot_events if event["result"] == "make")
+    misses = sum(1 for event in shot_events if event["result"] == "miss")
+    total_shots = makes + misses
+
+    shot_event_columns = _get_table_columns(db, "shot_events")
+
+    report = Report(
+        session_id=session_id,
+        raw_text=content,
+        total_shots=total_shots,
+        makes=makes,
+        misses=misses,
+    )
+
+    try:
+        db.add(report)
+        db.flush()
+
+        rows = []
+        for event in shot_events:
+            row = {
+                "session_id": session_id,
+                "shot_number": event["shot_number"],
+                "result": event["result"],
+            }
+            if "start_frame" in shot_event_columns and event.get("start_frame") is not None:
+                row["start_frame"] = event.get("start_frame")
+            if "end_frame" in shot_event_columns and event.get("end_frame") is not None:
+                row["end_frame"] = event.get("end_frame")
+            if "elbow_angle" in shot_event_columns and event.get("elbow_angle") is not None:
+                row["elbow_angle"] = event.get("elbow_angle")
+            if "shoulder_angle" in shot_event_columns and event.get("shoulder_angle") is not None:
+                row["shoulder_angle"] = event.get("shoulder_angle")
+            rows.append(row)
+
+        if rows:
+            db.bulk_insert_mappings(ShotEvent, rows, render_nulls=False)
+
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    logger.info(
+        "Session %s: report parsed, %s shots persisted (%s makes, %s misses)",
+        session_id,
+        total_shots,
+        makes,
+        misses,
+    )
+
+
+def _get_table_columns(db, table_name: str) -> set[str]:
+    bind = db.get_bind()
+    return {column["name"] for column in inspect(bind).get_columns(table_name)}
+
+
+def _normalize_outcome(raw: str | None) -> str:
+    normalized = (raw or "").strip().lower()
+    if normalized in {"made", "make", "1", "true"}:
+        return "make"
+    if normalized in {"missed", "miss", "0", "false"}:
+        return "miss"
+    return "miss"
+
+
+def _parse_float(line: str, pattern: str):
+    match = re.search(pattern, line, re.IGNORECASE)
+    if not match:
+        return None
+    try:
+        return float(match.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_shot_lines(content: str):
+    parsed = []
+    for line in content.splitlines():
+        match = re.search(r"Shot\s*(\d+)\s*[:\-]?\s*(made|missed|make|miss)\b", line, re.IGNORECASE)
+        if not match:
+            continue
+
+        shot_number = int(match.group(1))
+        result = _normalize_outcome(match.group(2))
+        release_angle = _parse_float(line, r"(?:release|shoulder)(?:\s*angle)?\s*[=:]\s*([-+]?\d+(?:\.\d+)?)")
+        elbow_angle = _parse_float(line, r"elbow(?:\s*angle)?\s*[=:]\s*([-+]?\d+(?:\.\d+)?)")
+
+        parsed.append(
+            {
+                "shot_number": shot_number,
+                "result": result,
+                "elbow_angle": elbow_angle,
+                "shoulder_angle": release_angle,
+            }
+        )
+
+    return parsed
+
+
+def _parse_analysis_blocks(content: str):
+    parsed = []
+    blocks = [block.strip() for block in re.split(r"\n\s*\n", content) if block.strip()]
+
+    for index, block in enumerate(blocks, start=1):
+        shot_number_match = re.search(r"\bshot\s*(\d+)\b", block, re.IGNORECASE)
+        shot_number = int(shot_number_match.group(1)) if shot_number_match else index
+
+        # Current HumanTracksDrawer format marks positive blocks as GOOD FORM.
+        result = "make" if re.search(r"\bGOOD\s+FORM\b", block, re.IGNORECASE) else "miss"
+
+        parsed.append(
+            {
+                "shot_number": shot_number,
+                "result": result,
+                "elbow_angle": None,
+                "shoulder_angle": None,
+            }
+        )
+
+    return parsed

--- a/env.example
+++ b/env.example
@@ -37,5 +37,9 @@ JWT_SECRET_KEY=your-jwt-secret-here
 JWT_ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 
+# ── Admin Forced Reset (Backend) ──────────────
+# Required for POST /api/auth/admin/force-reset-password
+ADMIN_RESET_KEY=meow
+
 # ── CORS ──────────────────────────────────────
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8000

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -194,14 +194,95 @@ class TestRegistration:
 
 class TestLogin:
     def test_login_success(self, client):
-        client.post("/api/register", json={"name": "Test", "email": "login@example.com", "password": "Password1"})
-        res = client.post("/api/login", json={"email": "login@example.com", "password": "Password1"})
+        client.post("/api/auth/register", json={"name": "Test", "email": "login@example.com", "password": "Password1"})
+        res = client.post("/api/auth/login", json={"email": "login@example.com", "password": "Password1"})
         assert res.status_code == 200
         assert "access_token" in res.json()
 
     def test_login_invalid_credentials(self, client):
-        res = client.post("/api/login", json={"email": "noone@example.com", "password": "Wrong123"})
+        res = client.post("/api/auth/login", json={"email": "noone@example.com", "password": "Wrong123"})
         assert res.status_code == 401
+
+
+class TestResetPassword:
+    def test_reset_password_success_then_login_with_new_password(self, client):
+        register_res = client.post(
+            "/api/auth/register",
+            json={"name": "Reset User", "email": "reset@example.com", "password": "Password1"},
+        )
+        assert register_res.status_code == 201
+
+        reset_res = client.post(
+            "/api/auth/reset-password",
+            json={
+                "email": "reset@example.com",
+                "current_password": "Password1",
+                "new_password": "Password2",
+            },
+        )
+        assert reset_res.status_code == 200
+        assert "updated" in reset_res.json().get("message", "").lower()
+
+        old_login = client.post(
+            "/api/auth/login",
+            json={"email": "reset@example.com", "password": "Password1"},
+        )
+        assert old_login.status_code == 401
+
+        new_login = client.post(
+            "/api/auth/login",
+            json={"email": "reset@example.com", "password": "Password2"},
+        )
+        assert new_login.status_code == 200
+        assert "access_token" in new_login.json()
+
+    def test_reset_password_rejects_invalid_current_password(self, client):
+        client.post(
+            "/api/auth/register",
+            json={"name": "Reset User 2", "email": "reset2@example.com", "password": "Password1"},
+        )
+
+        reset_res = client.post(
+            "/api/auth/reset-password",
+            json={
+                "email": "reset2@example.com",
+                "current_password": "WrongPassword1",
+                "new_password": "Password2",
+            },
+        )
+        assert reset_res.status_code == 401
+
+    def test_reset_password_rejects_weak_new_password(self, client):
+        client.post(
+            "/api/auth/register",
+            json={"name": "Reset User 3", "email": "reset3@example.com", "password": "Password1"},
+        )
+
+        reset_res = client.post(
+            "/api/auth/reset-password",
+            json={
+                "email": "reset3@example.com",
+                "current_password": "Password1",
+                "new_password": "short",
+            },
+        )
+        assert reset_res.status_code == 422
+
+    def test_reset_password_rejects_same_new_password(self, client):
+        client.post(
+            "/api/auth/register",
+            json={"name": "Reset User 4", "email": "reset4@example.com", "password": "Password1"},
+        )
+
+        reset_res = client.post(
+            "/api/auth/reset-password",
+            json={
+                "email": "reset4@example.com",
+                "current_password": "Password1",
+                "new_password": "Password1",
+            },
+        )
+        assert reset_res.status_code == 422
 
 
 class TestLogout:

--- a/tests/test_pipeline_task.py
+++ b/tests/test_pipeline_task.py
@@ -1,3 +1,6 @@
+import sys
+import types
+
 from app.models.session import SessionModel
 from app.models.user import User
 from app.tasks.pipeline_task import process_video
@@ -30,3 +33,41 @@ class TestPipelineTask:
         refreshed = db_session.query(SessionModel).filter(SessionModel.id == session.id).first()
         assert refreshed is not None
         assert refreshed.status == "failed"
+
+    def test_process_video_failure_does_not_delete_original_input_video(self, db_session, monkeypatch, tmp_path):
+        user = User(name="Input Preserve", email="input-preserve@example.com", password_hash="hash")
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+
+        monkeypatch.chdir(tmp_path)
+        input_dir = tmp_path / "input_videos"
+        input_dir.mkdir(parents=True, exist_ok=True)
+        source_video = input_dir / "sample.mp4"
+        source_video.write_bytes(b"video-bytes")
+
+        session = SessionModel(
+            user_id=user.id,
+            original_filename="sample.mp4",
+            upload_path=str(source_video),
+            status="queued",
+        )
+        db_session.add(session)
+        db_session.commit()
+        db_session.refresh(session)
+
+        fake_main = types.ModuleType("main")
+
+        def _raise_pipeline_error(_input_path, session_id):
+            raise RuntimeError(f"forced failure for session {session_id}")
+
+        fake_main.run_pipeline = _raise_pipeline_error
+        monkeypatch.setitem(sys.modules, "main", fake_main)
+
+        process_video.run(session.id)
+
+        db_session.expire_all()
+        refreshed = db_session.query(SessionModel).filter(SessionModel.id == session.id).first()
+        assert refreshed is not None
+        assert refreshed.status == "failed"
+        assert source_video.exists()

--- a/tests/test_report_parser.py
+++ b/tests/test_report_parser.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+from app.models.report import Report
+from app.models.shot_event import ShotEvent
+from app.models.session import SessionModel
+from app.models.user import User
+from app.tasks.report_parser import parse_and_persist
+
+
+def _make_session(db_session, email="parser@example.com"):
+    user = User(name="Parser User", email=email, password_hash="hash")
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    session = SessionModel(
+        user_id=user.id,
+        original_filename="clip.mp4",
+        upload_path="uploads/clip.mp4",
+        status="completed",
+    )
+    db_session.add(session)
+    db_session.commit()
+    db_session.refresh(session)
+    return session
+
+
+class TestReportParser:
+    def test_parse_and_persist_with_shot_lines(self, db_session, tmp_path):
+        session = _make_session(db_session, email="shot-lines@example.com")
+        report_path = Path(tmp_path) / "sample_report.txt"
+        report_path.write_text(
+            "Shot 1: made, release=48.3, elbow=92.1\n"
+            "Shot 2: missed, release=44.0, elbow=88.4\n",
+            encoding="utf-8",
+        )
+
+        parse_and_persist(session.id, str(report_path), db_session)
+
+        report = db_session.query(Report).filter(Report.session_id == session.id).one()
+        assert report.total_shots == 2
+        assert report.makes == 1
+        assert report.misses == 1
+        assert "Shot 1: made" in report.raw_text
+
+        shot_events = (
+            db_session.query(ShotEvent)
+            .filter(ShotEvent.session_id == session.id)
+            .order_by(ShotEvent.shot_number)
+            .all()
+        )
+        assert len(shot_events) == 2
+        assert shot_events[0].result == "make"
+        assert shot_events[1].result == "miss"
+        assert shot_events[0].shoulder_angle == 48.3
+        assert shot_events[0].elbow_angle == 92.1
+
+    def test_parse_and_persist_with_analysis_blocks(self, db_session, tmp_path):
+        session = _make_session(db_session, email="analysis-blocks@example.com")
+        report_path = Path(tmp_path) / "analysis_report.txt"
+        report_path.write_text(
+            "GOOD FORM\n\n"
+            "shot 2\n"
+            "NEEDS WORK:\n"
+            "Your SEW angle is too low\n",
+            encoding="utf-8",
+        )
+
+        parse_and_persist(session.id, str(report_path), db_session)
+
+        report = db_session.query(Report).filter(Report.session_id == session.id).one()
+        assert report.total_shots == 2
+        assert report.makes == 1
+        assert report.misses == 1
+
+        shot_events = (
+            db_session.query(ShotEvent)
+            .filter(ShotEvent.session_id == session.id)
+            .order_by(ShotEvent.shot_number)
+            .all()
+        )
+        assert len(shot_events) == 2
+        assert shot_events[0].shot_number == 1
+        assert shot_events[1].shot_number == 2
+        assert shot_events[0].result == "make"
+        assert shot_events[1].result == "miss"
+
+    def test_parse_and_persist_zero_shot_report_still_inserts_report(self, db_session, tmp_path):
+        session = _make_session(db_session, email="zero-shot@example.com")
+        report_path = Path(tmp_path) / "empty_report.txt"
+        report_path.write_text("", encoding="utf-8")
+
+        parse_and_persist(session.id, str(report_path), db_session)
+
+        report = db_session.query(Report).filter(Report.session_id == session.id).one()
+        assert report.total_shots == 0
+        assert report.makes == 0
+        assert report.misses == 0
+
+        shot_event_count = db_session.query(ShotEvent).filter(ShotEvent.session_id == session.id).count()
+        assert shot_event_count == 0

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -6,6 +6,7 @@ from app.main import app
 from app.api import sessions as sessions_api
 from app.config import settings
 from app.core.security import create_access_token
+from app.models.session import SessionModel
 from app.models.user import User
 
 
@@ -104,3 +105,68 @@ class TestSessions:
 
         expected_path = tmp_path / f"{body['id']}.mp4"
         assert expected_path.exists()
+
+    def test_delete_session_success_returns_204(self, client, db_session):
+        user = User(name="Delete OK", email="delete-ok@example.com", password_hash="hash")
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+        token = create_access_token({"sub": str(user.id)})
+
+        session = SessionModel(
+            user_id=user.id,
+            original_filename="delete_me.mp4",
+            status="completed",
+        )
+        db_session.add(session)
+        db_session.commit()
+        db_session.refresh(session)
+        session_id = session.id
+
+        res = client.delete(f"/api/sessions/{session_id}", headers={"Authorization": f"Bearer {token}"})
+        assert res.status_code == 204
+
+        db_session.expire_all()
+        found = db_session.query(SessionModel).filter(SessionModel.id == session_id).first()
+        assert found is None
+
+    def test_delete_session_processing_returns_409(self, client, db_session):
+        user = User(name="Delete Busy", email="delete-busy@example.com", password_hash="hash")
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+        token = create_access_token({"sub": str(user.id)})
+
+        session = SessionModel(
+            user_id=user.id,
+            original_filename="busy.mp4",
+            status="processing",
+        )
+        db_session.add(session)
+        db_session.commit()
+        db_session.refresh(session)
+
+        res = client.delete(f"/api/sessions/{session.id}", headers={"Authorization": f"Bearer {token}"})
+        assert res.status_code == 409
+        assert "processed" in res.json().get("detail", "").lower()
+
+    def test_delete_session_other_user_returns_403(self, client, db_session):
+        owner = User(name="Owner", email="owner@example.com", password_hash="hash")
+        intruder = User(name="Intruder", email="intruder@example.com", password_hash="hash")
+        db_session.add_all([owner, intruder])
+        db_session.commit()
+        db_session.refresh(owner)
+        db_session.refresh(intruder)
+
+        intruder_token = create_access_token({"sub": str(intruder.id)})
+        session = SessionModel(
+            user_id=owner.id,
+            original_filename="private.mp4",
+            status="completed",
+        )
+        db_session.add(session)
+        db_session.commit()
+        db_session.refresh(session)
+
+        res = client.delete(f"/api/sessions/{session.id}", headers={"Authorization": f"Bearer {intruder_token}"})
+        assert res.status_code == 403


### PR DESCRIPTION
Backend: normalize emails and enforce case-insensitive uniqueness, add user reset-password and admin force-reset-password endpoints (admin protected by X-Admin-Reset-Key using secrets.compare_digest), validate password strength, and add a /sessions/{id}/retry endpoint to requeue failed sessions and dispatch processing. Config: add ADMIN_RESET_KEY setting. Frontend: introduce react-router, AuthContext and NavBar, add Dashboard and Sessions pages, wire routing for login/register/shots/upload, update Login and Register flows (login now supports password-reset flow) and make components use auth state/navigation. Add DB migration for shot event angles and update tests to cover new functionality.