### PR TITLE
SCRUM-112: Add inline tooltips for metrics and no-pose-data fallback

### DIFF
--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -9,7 +9,6 @@ import SessionsPage from "./pages/SessionsPage";
 import UploadPage from "./pages/UploadPage";
 import ResultsPage from "./pages/ResultsPage";
 import SessionDetailPage from "./pages/SessionDetailPage";
-import ResultsPage from "./pages/ResultsPage";
 
 function ProtectedRoute({ children }) {
   const { token } = useAuth();

--- a/app/frontend/src/components/Tooltip.jsx
+++ b/app/frontend/src/components/Tooltip.jsx
@@ -1,0 +1,12 @@
+export default function Tooltip({ text, label }) {
+  return (
+    <span className="tooltip-wrap" tabIndex={0}>
+      <span className="tooltip-icon" aria-label={label || 'What is this metric?'}>
+        &#9432;
+      </span>
+      <span className="tooltip-text" role="tooltip">
+        {text}
+      </span>
+    </span>
+  );
+}

--- a/app/frontend/src/components/Tooltip.jsx
+++ b/app/frontend/src/components/Tooltip.jsx
@@ -1,10 +1,22 @@
+import { useId } from "react";
+
 export default function Tooltip({ text, label }) {
+  const tooltipId = useId();
+  const accessibleName = label || "What is this metric?";
+
   return (
-    <span className="tooltip-wrap" tabIndex={0}>
-      <span className="tooltip-icon" aria-label={label || 'What is this metric?'}>
-        &#9432;
-      </span>
-      <span className="tooltip-text" role="tooltip">
+    <span className="tooltip-wrap">
+      <button
+        type="button"
+        className="tooltip-trigger"
+        aria-label={accessibleName}
+        aria-describedby={tooltipId}
+      >
+        <span className="tooltip-icon" aria-hidden="true">
+          &#9432;
+        </span>
+      </button>
+      <span id={tooltipId} className="tooltip-text" role="tooltip">
         {text}
       </span>
     </span>

--- a/app/frontend/src/index.css
+++ b/app/frontend/src/index.css
@@ -16,12 +16,32 @@ code {
 .tooltip-wrap {
   position: relative;
   display: inline-block;
+}
+.tooltip-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0 0 0 4px;
   cursor: help;
+  color: inherit;
+  font: inherit;
+  line-height: 1;
+}
+.tooltip-trigger:focus {
+  outline: none;
+}
+.tooltip-trigger:focus-visible {
+  outline: 2px solid #ff9a00;
+  outline-offset: 2px;
+  border-radius: 3px;
 }
 .tooltip-icon {
-  color: #6b7280;
+  color: currentColor;
+  opacity: 0.75;
   font-size: 0.85rem;
-  margin-left: 4px;
 }
 .tooltip-text {
   visibility: hidden;
@@ -42,7 +62,8 @@ code {
   pointer-events: none;
 }
 .tooltip-wrap:hover .tooltip-text,
-.tooltip-wrap:focus .tooltip-text {
+.tooltip-trigger:focus-visible + .tooltip-text,
+.tooltip-trigger:focus + .tooltip-text {
   visibility: visible;
   opacity: 1;
 }

--- a/app/frontend/src/index.css
+++ b/app/frontend/src/index.css
@@ -11,3 +11,48 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+/* ── Reusable metric tooltip ────────────────────────────────────────────── */
+.tooltip-wrap {
+  position: relative;
+  display: inline-block;
+  cursor: help;
+}
+.tooltip-icon {
+  color: #6b7280;
+  font-size: 0.85rem;
+  margin-left: 4px;
+}
+.tooltip-text {
+  visibility: hidden;
+  opacity: 0;
+  position: absolute;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1f2937;
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  width: 220px;
+  white-space: normal;
+  transition: opacity 0.2s;
+  z-index: 100;
+  pointer-events: none;
+}
+.tooltip-wrap:hover .tooltip-text,
+.tooltip-wrap:focus .tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}
+
+.info-msg {
+  background: #fffbeb;
+  border: 1px solid #fcd34d;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  color: #92400e;
+  font-size: 0.9rem;
+  margin: 1rem 0;
+}

--- a/app/frontend/src/pages/ResultsPage.jsx
+++ b/app/frontend/src/pages/ResultsPage.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import { Doughnut } from 'react-chartjs-2';
 import './ResultsPage.css';
+import MetricTooltip from '../components/Tooltip';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
@@ -22,7 +23,7 @@ function apiFetch(path) {
 }
 
 export default function ResultsPage() {
-  const { id: sessionId } = useParams();
+  const { sessionId } = useParams();
   const navigate = useNavigate();
 
   // 'loading' | 'processing' | 'queued' | 'failed' | 'completed'
@@ -193,8 +194,20 @@ export default function ResultsPage() {
                 <tr>
                   <th style={s.th}>#</th>
                   <th style={s.th}>Outcome</th>
-                  <th style={s.th}>Release Angle</th>
-                  <th style={s.th}>Elbow Angle</th>
+                  <th style={s.th}>
+                    Release Angle
+                    <MetricTooltip
+                      text="The angle of the ball's trajectory at the moment it leaves your hands. The ideal range is 45–55°."
+                      label="What is Release Angle?"
+                    />
+                  </th>
+                  <th style={s.th}>
+                    Elbow Angle
+                    <MetricTooltip
+                      text="The angle at your shooting elbow at the point of release. Consistent values across shots indicate repeatable form."
+                      label="What is Elbow Angle?"
+                    />
+                  </th>
                 </tr>
               </thead>
               <tbody>

--- a/app/frontend/src/pages/SessionDetailPage.jsx
+++ b/app/frontend/src/pages/SessionDetailPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import Tooltip from '../components/Tooltip';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
 
@@ -57,15 +58,27 @@ export default function SessionDetailPage() {
       </h2>
 
       {shots.length === 0 ? (
-        <p style={styles.msg}>No shot data available yet.</p>
+        <p className="info-msg">
+          ⚠️ Pose data unavailable for this session. The player may have been out of frame
+          or occluded during shot attempts.
+        </p>
       ) : (
         <div style={styles.tableWrap}>
           <table style={styles.table}>
             <thead>
               <tr>
-                {['Shot', 'Frame', 'Elbow Angle', 'Shoulder Angle', 'Knee Angle', 'Outcome'].map((h) => (
-                  <th key={h} style={styles.th}>{h}</th>
-                ))}
+                <th style={styles.th}>Shot</th>
+                <th style={styles.th}>Frame</th>
+                <th style={styles.th}>
+                  Elbow Angle
+                  <Tooltip
+                    text="The angle at your shooting elbow at the point of release. Consistent values across shots indicate repeatable form."
+                    label="What is Elbow Angle?"
+                  />
+                </th>
+                <th style={styles.th}>Shoulder Angle</th>
+                <th style={styles.th}>Knee Angle</th>
+                <th style={styles.th}>Outcome</th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
- Add tooltip CSS to index.css (global, keyboard-accessible via tabindex)
- Create reusable Tooltip component (src/components/Tooltip.jsx)
- Add Release Angle and Elbow Angle tooltips to ResultsPage shot table
- Add Elbow Angle tooltip to SessionDetailPage angle table
- Show warning message when angles API returns empty frames array
- Fix duplicate ResultsPage import in App.js (build error)
- Fix useParams key mismatch in ResultsPage (id → sessionId)