### PR TITLE
Rename release angle to SEW/ESH and update API/UI

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -305,7 +305,7 @@ def get_output_video(
     
     if not os.path.exists(video_path):
         logging.error(f"Video file not found: {video_path}")
-        raise HTTPException(status_code=404, detail=f"Output video not found at {video_path}")
+        raise HTTPException(status_code=404, detail="Output video not found")
 
     file_size = os.path.getsize(video_path)
     if file_size == 0:

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -356,7 +356,7 @@ def get_angles(
     # Create a frame -> shot_number mapping
     frame_to_shot = {}
     for shot in shot_events:
-        if shot.start_frame and shot.end_frame:
+        if shot.start_frame is not None and shot.end_frame is not None:
             for frame_num in range(shot.start_frame, shot.end_frame + 1):
                 frame_to_shot[frame_num] = shot.shot_number
     

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -235,6 +235,8 @@ def get_shots(session: SessionModel = Depends(verify_session_ownership), db: Ses
             "outcome": normalize_result(s.result),
             "sew_angle": s.elbow_angle,
             "esh_angle": s.shoulder_angle,
+            "elbow_angle_at_release": s.elbow_angle,
+            "release_angle": s.shoulder_angle,
         }
         for s in shots
     ]

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -192,18 +192,29 @@ def get_report(
         raise HTTPException(status_code=404, detail="Report not available yet. Session may still be processing.")
     total = report.total_shots or 0
     makes = report.makes or 0
-    avg_angle = (
+    
+    # Calculate average SEW angle (stored in elbow_angle column)
+    avg_sew_angle = (
+        db.query(func.avg(ShotEvent.elbow_angle))
+        .filter(ShotEvent.session_id == session.id, ShotEvent.elbow_angle.isnot(None))
+        .scalar()
+    )
+    
+    # Calculate average ESH angle (stored in shoulder_angle column)
+    avg_esh_angle = (
         db.query(func.avg(ShotEvent.shoulder_angle))
         .filter(ShotEvent.session_id == session.id, ShotEvent.shoulder_angle.isnot(None))
         .scalar()
     )
+    
     return ReportResponse(
         session_id=session.id,
         shot_percentage=round(makes / total * 100, 1) if total > 0 else None,
         shots_made=makes,
         shots_missed=report.misses or 0,
         total_shots=total,
-        avg_release_angle=round(avg_angle, 1) if avg_angle is not None else None,
+        avg_sew_angle=round(avg_sew_angle, 1) if avg_sew_angle is not None else None,
+        avg_esh_angle=round(avg_esh_angle, 1) if avg_esh_angle is not None else None,
         feedback_text=report.raw_text,
     )
 
@@ -222,8 +233,8 @@ def get_shots(session: SessionModel = Depends(verify_session_ownership), db: Ses
         {
             "shot_number": s.shot_number,
             "outcome": normalize_result(s.result),
-            "release_angle": s.shoulder_angle,
-            "elbow_angle_at_release": s.elbow_angle,
+            "sew_angle": s.elbow_angle,
+            "esh_angle": s.shoulder_angle,
         }
         for s in shots
     ]
@@ -281,14 +292,39 @@ def get_output_video(
     else:
         raise HTTPException(status_code=401, detail="Authentication required")
 
-    if not session.output_path or not os.path.exists(session.output_path):
-        raise HTTPException(status_code=404, detail="Output video not available")
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+        
+    if not session.output_path:
+        raise HTTPException(status_code=404, detail="Output video path not set")
+    
+    video_path = session.output_path
+    logging.info(f"Attempting to serve video from: {video_path}")
+    
+    if not os.path.exists(video_path):
+        logging.error(f"Video file not found: {video_path}")
+        raise HTTPException(status_code=404, detail=f"Output video not found at {video_path}")
 
-    mime_type, _ = mimetypes.guess_type(session.output_path)
+    file_size = os.path.getsize(video_path)
+    if file_size == 0:
+        logging.error(f"Video file is empty: {video_path}")
+        raise HTTPException(status_code=500, detail="Output video is empty")
+    
+    logging.info(f"Serving video file: {video_path} (size: {file_size} bytes)")
+    
+    # Force video/mp4 for MP4 files
+    if video_path.lower().endswith('.mp4'):
+        media_type = "video/mp4"
+    else:
+        mime_type, _ = mimetypes.guess_type(video_path)
+        media_type = mime_type or "video/mp4"
+    
+    logging.info(f"Using media type: {media_type}")
+    
     return FileResponse(
-        path=session.output_path,
-        media_type=mime_type or "application/octet-stream",
-        filename=os.path.basename(session.output_path),
+        path=video_path,
+        media_type=media_type,
+        filename=os.path.basename(video_path),
     )
 
 
@@ -299,23 +335,42 @@ def get_angles(
 ):
     from app.models.angle_frame import AngleFrame
 
-    rows = (
+    # Get all angle frames
+    angle_rows = (
         db.query(AngleFrame)
         .filter(AngleFrame.session_id == session.id)
         .order_by(AngleFrame.frame_number)
         .all()
     )
+    
+    # Get all shot events to map frames to shots
+    shot_events = (
+        db.query(ShotEvent)
+        .filter(ShotEvent.session_id == session.id)
+        .order_by(ShotEvent.shot_number)
+        .all()
+    )
+    
+    # Create a frame -> shot_number mapping
+    frame_to_shot = {}
+    for shot in shot_events:
+        if shot.start_frame and shot.end_frame:
+            for frame_num in range(shot.start_frame, shot.end_frame + 1):
+                frame_to_shot[frame_num] = shot.shot_number
+    
+    # Build response with shot numbers properly mapped
     frames = [
         {
-            "shot_number": idx + 1,
+            "shot_number": frame_to_shot.get(row.frame_number, 1),  # Default to 1 if not found
             "frame_number": row.frame_number,
             "elbow_angle": row.elbow_angle,
             "knee_angle": row.knee_angle,
             "shoulder_angle": row.shoulder_angle,
             "outcome": None,
         }
-        for idx, row in enumerate(rows)
+        for row in angle_rows
     ]
+    
     return {"session_id": session.id, "frames": frames}
 
 @router.post("/{session_id}/retry", response_model=SessionResponse)

--- a/app/frontend/src/pages/ResultsPage.jsx
+++ b/app/frontend/src/pages/ResultsPage.jsx
@@ -281,7 +281,8 @@ export default function ResultsPage() {
       <div style={s.card}>
         <h3 style={s.cardTitle}>Annotated Video</h3>
         {videoSrc ? (
-          <video key={videoSrc} controls width="100%" preload="auto" style={s.video} src={videoSrc} type="video/mp4">
+          <video key={videoSrc} controls width="100%" preload="metadata" style={s.video}>
+            <source src={videoSrc} type="video/mp4" />
             Your browser does not support HTML5 video.
           </video>
         ) : (

--- a/app/frontend/src/pages/ResultsPage.jsx
+++ b/app/frontend/src/pages/ResultsPage.jsx
@@ -242,17 +242,17 @@ export default function ResultsPage() {
                   <th style={s.th}>#</th>
                   <th style={s.th}>Outcome</th>
                   <th style={s.th}>
-                    Release Angle
+                    SEW Angle
                     <MetricTooltip
-                      text="The angle of the ball's trajectory at the moment it leaves your hands. The ideal range is 45–55°."
-                      label="What is Release Angle?"
+                      text="Shoulder-Elbow-Wrist angle at release. Indicates your arm form and shooting consistency. Ideal range is 65–75°."
+                      label="What is SEW Angle?"
                     />
                   </th>
                   <th style={s.th}>
-                    Elbow Angle
+                    ESH Angle
                     <MetricTooltip
-                      text="The angle at your shooting elbow at the point of release. Consistent values across shots indicate repeatable form."
-                      label="What is Elbow Angle?"
+                      text="Elbow-Shoulder-Hip angle at release. Indicates your shooting arc. Ideal range is 120–135°."
+                      label="What is ESH Angle?"
                     />
                   </th>
                 </tr>
@@ -266,8 +266,8 @@ export default function ResultsPage() {
                       <td style={{ ...s.td, color: outcome === 'made' ? '#22c55e' : '#ef4444', fontWeight: 600 }}>
                         {outcome}
                       </td>
-                      <td style={s.td}>{shot.release_angle != null ? `${shot.release_angle.toFixed(1)}°` : '—'}</td>
-                      <td style={s.td}>{shot.elbow_angle_at_release != null ? `${shot.elbow_angle_at_release.toFixed(1)}°` : '—'}</td>
+                      <td style={s.td}>{shot.sew_angle != null ? `${shot.sew_angle.toFixed(1)}°` : '—'}</td>
+                      <td style={s.td}>{shot.esh_angle != null ? `${shot.esh_angle.toFixed(1)}°` : '—'}</td>
                     </tr>
                   );
                 })}
@@ -281,7 +281,7 @@ export default function ResultsPage() {
       <div style={s.card}>
         <h3 style={s.cardTitle}>Annotated Video</h3>
         {videoSrc ? (
-          <video key={videoSrc} controls width="100%" preload="metadata" style={s.video} src={videoSrc}>
+          <video key={videoSrc} controls width="100%" preload="auto" style={s.video} src={videoSrc} type="video/mp4">
             Your browser does not support HTML5 video.
           </video>
         ) : (
@@ -298,16 +298,18 @@ export default function ResultsPage() {
 
 function renderFormAnalysis(report, animate, angleFrames, chartRef, sessionId) {
   const consistencyScore = getNullableNumber(report?.shot_percentage);
-  const avgReleaseAngle = getNullableNumber(report?.avg_release_angle);
+  const avgSewAngle = getNullableNumber(report?.avg_sew_angle);
+  const avgEshAngle = getNullableNumber(report?.avg_esh_angle);
   const feedbackText = normalizeFeedbackText(report?.feedback_text);
   const consistencyLabel = getConsistencyLabel(consistencyScore);
-  const releaseTone = getReleaseTone(avgReleaseAngle);
+  const sewTone = getAngleTone(avgSewAngle, 65, 75);
+  const eshTone = getAngleTone(avgEshAngle, 120, 135);
 
   return (
     <div style={s.card}>
       <h3 style={s.cardTitle}>Form Analysis</h3>
       <div style={s.formAnalysisGrid}>
-        <section style={s.analysisBlock}>
+        <section style={{ ...s.analysisBlock, ...s.consistencyBlockFull }}>
           <div style={s.analysisHeader}>
             <span style={s.analysisLabel}>Consistency Score</span>
             <span style={s.analysisMeta}>{consistencyLabel}</span>
@@ -332,28 +334,28 @@ function renderFormAnalysis(report, animate, angleFrames, chartRef, sessionId) {
 
         <section style={s.analysisBlock}>
           <div style={s.analysisHeader}>
-            <span style={s.analysisLabel}>Average Release Angle</span>
-            <span style={{ ...s.analysisMeta, color: releaseTone.color }}>{releaseTone.label}</span>
+            <span style={s.analysisLabel}>Average SEW Angle</span>
+            <span style={{ ...s.analysisMeta, color: sewTone.color }}>{sewTone.label}</span>
           </div>
           <div style={s.angleValueRow}>
-            <div style={{ ...s.angleValue, color: releaseTone.color }}>
-              {avgReleaseAngle != null ? `${avgReleaseAngle.toFixed(1)}°` : 'N/A'}
+            <div style={{ ...s.angleValue, color: sewTone.color }}>
+              {avgSewAngle != null ? `${avgSewAngle.toFixed(1)}°` : 'N/A'}
             </div>
-            <div style={s.angleBandWrap} aria-label="Release angle reference band">
+            <div style={s.angleBandWrap} aria-label="SEW angle reference band">
               <div style={s.angleScale}>
                 <div
                   style={{
                     ...s.angleIdealBand,
-                    left: '50%',
-                    width: '11.1%',
+                    left: `${(65 / 180) * 100}%`,
+                    width: `${((75 - 65) / 180) * 100}%`,
                   }}
                 />
                 <div style={s.angleMarkerRail} />
-                {avgReleaseAngle != null ? (
+                {avgSewAngle != null ? (
                   <div
                     style={{
                       ...s.angleMarker,
-                      left: `${Math.max(0, Math.min(100, (avgReleaseAngle / 90) * 100))}%`,
+                      left: `${Math.max(0, Math.min(100, (avgSewAngle / 180) * 100))}%`,
                       opacity: animate ? 1 : 0,
                     }}
                   />
@@ -361,8 +363,46 @@ function renderFormAnalysis(report, animate, angleFrames, chartRef, sessionId) {
               </div>
               <div style={s.angleScaleLabels}>
                 <span>0°</span>
-                <span>Ideal: 45–55°</span>
-                <span>90°</span>
+                <span>Ideal: 65–75°</span>
+                <span>180°</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section style={s.analysisBlock}>
+          <div style={s.analysisHeader}>
+            <span style={s.analysisLabel}>Average ESH Angle</span>
+            <span style={{ ...s.analysisMeta, color: eshTone.color }}>{eshTone.label}</span>
+          </div>
+          <div style={s.angleValueRow}>
+            <div style={{ ...s.angleValue, color: eshTone.color }}>
+              {avgEshAngle != null ? `${avgEshAngle.toFixed(1)}°` : 'N/A'}
+            </div>
+            <div style={s.angleBandWrap} aria-label="ESH angle reference band">
+              <div style={s.angleScale}>
+                <div
+                  style={{
+                    ...s.angleIdealBand,
+                    left: `${(120 / 180) * 100}%`,
+                    width: `${((135 - 120) / 180) * 100}%`,
+                  }}
+                />
+                <div style={s.angleMarkerRail} />
+                {avgEshAngle != null ? (
+                  <div
+                    style={{
+                      ...s.angleMarker,
+                      left: `${Math.max(0, Math.min(100, (avgEshAngle / 180) * 100))}%`,
+                      opacity: animate ? 1 : 0,
+                    }}
+                  />
+                ) : null}
+              </div>
+              <div style={s.angleScaleLabels}>
+                <span>0°</span>
+                <span>Ideal: 120–135°</span>
+                <span>180°</span>
               </div>
             </div>
           </div>
@@ -378,10 +418,10 @@ function renderFormAnalysis(report, animate, angleFrames, chartRef, sessionId) {
         {angleFrames.length > 0 && (
           <section style={{ ...s.analysisBlock, ...s.chartBlock }}>
             <div style={s.analysisHeader}>
-              <span style={s.analysisLabel}>Elbow Angle by Frame</span>
+              <span style={s.analysisLabel}>Angles by Shot</span>
             </div>
             <div style={s.chartContainer}>
-              <canvas id="elbow-angle-chart" ref={chartRef} width="400" height="200" />
+              <canvas id="angles-chart" ref={chartRef} width="400" height="200" />
             </div>
           </section>
         )}
@@ -411,16 +451,16 @@ function getConsistencyLabel(score) {
   return 'Needs Work';
 }
 
-function getReleaseTone(angle) {
+function getAngleTone(angle, minThreshold, maxThreshold) {
   if (angle == null) {
     return { label: 'N/A', color: '#6b7280' };
   }
 
-  if (angle >= 45 && angle <= 55) {
+  if (angle >= minThreshold && angle <= maxThreshold) {
     return { label: 'Ideal', color: '#16a34a' };
   }
 
-  if (angle >= 40 && angle <= 60) {
+  if (angle >= minThreshold - 5 && angle <= maxThreshold + 5) {
     return { label: 'Near ideal', color: '#d97706' };
   }
 
@@ -432,11 +472,6 @@ function renderElbowAngleChart(angleFrames, chartRef, chartInstance) {
     return;
   }
 
-  const COLORS = [
-    '#3b82f6', '#22c55e', '#f59e0b', '#ef4444', '#8b5cf6',
-    '#06b6d4', '#f97316', '#ec4899', '#14b8a6', '#a3e635',
-  ];
-
   // Group frames by shot_number
   const shotMap = {};
   angleFrames.forEach((frame) => {
@@ -447,35 +482,61 @@ function renderElbowAngleChart(angleFrames, chartRef, chartInstance) {
     shotMap[shotNum].push(frame);
   });
 
-  // Build datasets per shot
-  const datasets = [];
+  // Get shot numbers in order
   const shotNumbers = Object.keys(shotMap)
     .map(Number)
     .sort((a, b) => a - b);
-  const maxLength = Math.max(...shotNumbers.map((n) => shotMap[n].length));
 
-  shotNumbers.forEach((shotNum, idx) => {
+  // Calculate average SEW and ESH for each shot
+  const sewData = [];
+  const eshData = [];
+
+  shotNumbers.forEach((shotNum) => {
     const frames = shotMap[shotNum];
-    const color = COLORS[idx % COLORS.length];
-    const data = frames.map((f) => f.elbow_angle);
+    
+    // Average SEW angle (elbow_angle)
+    const sewValues = frames.filter(f => f.elbow_angle != null).map(f => f.elbow_angle);
+    const sewAvg = sewValues.length > 0 ? sewValues.reduce((a, b) => a + b, 0) / sewValues.length : null;
+    sewData.push(sewAvg);
 
-    datasets.push({
-      label: `Shot ${shotNum}`,
-      data,
-      borderColor: color,
-      backgroundColor: `${color}08`,
+    // Average ESH angle (shoulder_angle)
+    const eshValues = frames.filter(f => f.shoulder_angle != null).map(f => f.shoulder_angle);
+    const eshAvg = eshValues.length > 0 ? eshValues.reduce((a, b) => a + b, 0) / eshValues.length : null;
+    eshData.push(eshAvg);
+  });
+
+  // Create datasets: one for SEW, one for ESH
+  const datasets = [
+    {
+      label: 'SEW Angle (65–75°)',
+      data: sewData,
+      borderColor: '#3b82f6',
+      backgroundColor: '#3b82f608',
       borderWidth: 2.5,
       tension: 0.3,
       spanGaps: true,
-      pointRadius: 3,
-      pointBackgroundColor: color,
+      pointRadius: 4,
+      pointBackgroundColor: '#3b82f6',
       pointBorderColor: '#fff',
       pointBorderWidth: 1.5,
-    });
-  });
+    },
+    {
+      label: 'ESH Angle (120–135°)',
+      data: eshData,
+      borderColor: '#f59e0b',
+      backgroundColor: '#f59e0b08',
+      borderWidth: 2.5,
+      tension: 0.3,
+      spanGaps: true,
+      pointRadius: 4,
+      pointBackgroundColor: '#f59e0b',
+      pointBorderColor: '#fff',
+      pointBorderWidth: 1.5,
+    },
+  ];
 
-  // Generate x-axis labels
-  const xLabels = Array.from({ length: maxLength }, (_, i) => `Frame ${i + 1}`);
+  // Generate x-axis labels (shot numbers)
+  const xLabels = shotNumbers.map((n) => `Shot ${n}`);
 
   const ctx = chartRef.current.getContext('2d');
   
@@ -503,26 +564,12 @@ function renderElbowAngleChart(angleFrames, chartRef, chartInstance) {
             color: '#374151',
           },
         },
-        annotation: {
-          annotations: {
-            releaseZone: {
-              type: 'box',
-              xMin: -0.5,
-              xMax: maxLength - 0.5,
-              yMin: 85,
-              yMax: 100,
-              backgroundColor: 'rgba(34, 197, 94, 0.15)',
-              borderColor: 'rgba(34, 197, 94, 0.4)',
-              borderWidth: 1.5,
-            },
-          },
-        },
       },
       scales: {
         x: {
           title: {
             display: true,
-            text: 'Frame',
+            text: 'Shot Number',
             font: { size: 13, weight: 600 },
             color: '#111827',
           },
@@ -537,11 +584,11 @@ function renderElbowAngleChart(angleFrames, chartRef, chartInstance) {
         y: {
           title: {
             display: true,
-            text: 'Elbow Angle (°)',
+            text: 'Angle (°)',
             font: { size: 13, weight: 600 },
             color: '#111827',
           },
-          min: 60,
+          min: 50,
           max: 180,
           ticks: {
             font: { size: 11 },
@@ -623,6 +670,9 @@ const s = {
     borderRadius: 12,
     padding: '1rem 1.1rem',
     background: 'linear-gradient(180deg, #ffffff 0%, #fbfcfe 100%)',
+  },
+  consistencyBlockFull: {
+    gridColumn: '1 / -1',
   },
   analysisHeader: {
     display: 'flex',

--- a/app/schemas/session.py
+++ b/app/schemas/session.py
@@ -31,8 +31,8 @@ class SessionListResponse(BaseModel):
 class ShotDetail(BaseModel):
     shot_number: int
     outcome: str  # "made" or "missed"
-    release_angle: Optional[float] = None
-    elbow_angle_at_release: Optional[float] = None
+    sew_angle: Optional[float] = None  # Shoulder-Elbow-Wrist angle at release
+    esh_angle: Optional[float] = None  # Elbow-Shoulder-Hip angle at release
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -53,7 +53,8 @@ class ReportResponse(BaseModel):
     shots_made: int = 0
     shots_missed: int = 0
     total_shots: int = 0
-    avg_release_angle: Optional[float] = None
+    avg_sew_angle: Optional[float] = None  # Average Shoulder-Elbow-Wrist angle
+    avg_esh_angle: Optional[float] = None  # Average Elbow-Shoulder-Hip angle
     feedback_text: Optional[str] = None
 
 

--- a/app/tasks/pipeline_task.py
+++ b/app/tasks/pipeline_task.py
@@ -106,6 +106,11 @@ def process_video(self, session_id: int):
         # Run the CV pipeline
         from main import run_pipeline
         output_path, report_path, pipeline_data = run_pipeline(input_path, session_id=session_id)
+        
+        # Convert to absolute paths
+        output_path = os.path.abspath(output_path)
+        report_path = os.path.abspath(report_path)
+        
         logger.info("Pipeline produced output_path=%s report_path=%s", output_path, report_path)
         if not os.path.exists(output_path):
             raise FileNotFoundError(f"Output video missing: {output_path}")

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -325,7 +325,7 @@ class TestSessions:
         assert body["shot_percentage"] == 66.7
         assert body["shots_made"] == 2
         assert body["shots_missed"] == 1
-        assert body["avg_release_angle"] == 47.0
+        assert body["avg_esh_angle"] == 47.0
         assert body["feedback_text"] == "solid form"
 
     def test_get_shots_and_angles_are_ordered(self, client, db_session):


### PR DESCRIPTION
Replace the single "release angle" metric with two angles: SEW (Shoulder-Elbow-Wrist) and ESH (Elbow-Shoulder-Hip). Backend: add avg_sew_angle and avg_esh_angle computations, rename shot output fields to sew_angle/esh_angle, map angle frames to shot numbers, and harden video serving (logging, path checks, media_type handling). Schemas updated to reflect new fields. Frontend: update labels, tooltips, UI tiles, charting (now plots per-shot SEW and ESH averages), and video tag attributes. Pipeline task: convert pipeline output/report paths to absolute. Tests adjusted to expect the renamed field.