### PR TITLE
docs: post-implementation refresh of SRS, SDS, and developer README

### DIFF
--- a/DEVELOPER_README.md
+++ b/DEVELOPER_README.md
@@ -1,0 +1,180 @@
+# SwishVision — Developer README
+
+Quick-start guide for running the SwishVision web application locally on Windows (PowerShell). For deeper detail on individual subsystems, see [`app/DEVELOPER_README.md`](app/DEVELOPER_README.md), [`docs/SwishVision_SRS.md`](docs/SwishVision_SRS.md), and [`docs/SwishVision_SDS.md`](docs/SwishVision_SDS.md).
+
+---
+
+## Stack
+
+| Layer | Technology |
+|---|---|
+| Frontend | React (Create React App) — `app/frontend/` |
+| Backend | FastAPI + Uvicorn — `app/main.py` |
+| Database | Microsoft SQL Server (via `pyodbc`) |
+| Task queue | Celery worker — `app/tasks/pipeline_task.py` |
+| Broker | Redis (`redis://localhost:6379/0`) |
+| CV pipeline | YOLOv8 (Ultralytics) + OpenCV + ffmpeg (imageio-ffmpeg) — `main.py`, `trackers/`, `drawers/`, `utils/` |
+
+The flow: React UI → FastAPI REST API → Celery enqueues a job on Redis → Celery worker invokes the CV pipeline → annotated H.264 mp4 + parsed report rows land in SQL Server → React reads them back.
+
+---
+
+## Prerequisites
+
+- Python 3.8+ (tested on 3.13) with `venv`
+- Node.js 18+
+- Microsoft SQL Server 2019+ with the **ODBC Driver 17 for SQL Server** installed (`Get-OdbcDriver` to verify)
+- Redis (a portable Windows binary works; see step 1 of "Running the app" below)
+- (Recommended) NVIDIA GPU with CUDA-compatible PyTorch for inference. CPU-only inference works but is roughly 10× slower.
+
+---
+
+## One-time setup
+
+```powershell
+# 1. Create venv + activate
+python -m venv .venv
+.venv\Scripts\Activate
+
+# 2. Install backend (FastAPI / SQLAlchemy / Celery / Redis client)
+pip install -r app/requirements.txt
+
+# 3. Install the CV pipeline runtime deps (NOT in app/requirements.txt — see "Known dependency gaps" below)
+pip install opencv-python ultralytics torch torchvision numpy matplotlib supervision pandas imageio-ffmpeg
+
+# 4. Pin a passlib-compatible bcrypt (see "Known dependency gaps")
+pip install "bcrypt==3.2.2"
+
+# 5. Install frontend deps
+cd app/frontend
+npm install
+cd ../..
+
+# 6. Configure env — copy template and edit
+copy env.example .env
+#   Critical edits:
+#     DB_DRIVER=ODBC Driver 17 for SQL Server     (NOT the legacy "SQL Server" driver)
+#     DB_TRUSTED_CONNECTION=true                   (Windows auth)
+#     SECRET_KEY=<random 256-bit secret>
+
+# 7. Create the database (SSMS or sqlcmd):
+#       CREATE DATABASE SwishVision;
+#    The schema itself is auto-created by SQLAlchemy's metadata.create_all() in app/main.py
+#    on first startup — running `alembic upgrade head` is optional and only needed if you
+#    are working with versioned migrations.
+```
+
+Make sure `models/best.pt` and `models/yolov8m-pose.pt` are present in `models/`. See [`README.md`](README.md) for sources.
+
+### Known dependency gaps in `app/requirements.txt`
+
+`app/requirements.txt` only lists web-stack packages — running it alone will not give you a working pipeline. We hit four real installation problems while bringing the system up; these are documented here so the next person doesn't repeat them:
+
+| Missing / wrong | Symptom | Fix |
+|---|---|---|
+| `redis` Python client | Celery worker dies on startup with `AttributeError: 'NoneType' object has no attribute 'Redis'` (kombu fails to import the redis transport) | `pip install redis==5.2.1` (already in `app/requirements.txt` but verify it actually installed) |
+| CV pipeline deps (`opencv-python`, `ultralytics`, `torch`, `torchvision`, `numpy`, `matplotlib`, `supervision`, `pandas`) | Sessions fail almost instantly with `ModuleNotFoundError: No module named 'cv2'` (or `supervision`, etc.) — surfaced in the worker log | Step 3 above |
+| `bcrypt==4.0.1` (pinned by `app/requirements.txt`) is incompatible with `passlib==1.7.4` | Every register/login crashes with `ValueError: password cannot be longer than 72 bytes` *inside passlib's own backend probe* | `pip install "bcrypt==3.2.2"` (step 4 above), or update the pin in `app/requirements.txt` |
+| `imageio-ffmpeg` not installed | Pipeline completes but the annotated video shows a blank player in the browser. Worker log says `ffmpeg not available (No module named 'imageio_ffmpeg'), keeping mp4v output.` mp4v in MP4 plays in VLC but not in Chrome / Firefox / Edge `<video>` elements. | `pip install imageio-ffmpeg`. The pipeline transcodes to H.264 (`libx264`, `yuv420p`, `+faststart`) on the second pass once this is present. |
+
+---
+
+## Running the app — four terminals
+
+You need **four** processes running simultaneously. Open a separate PowerShell terminal for each.
+
+### 1. Redis
+
+```powershell
+Start-Process -FilePath "$env:TEMP\redis\redis-server.exe" -ArgumentList "--port 6379 --bind 127.0.0.1" -WindowStyle Minimized
+```
+
+> First time only — download and extract the binary:
+> ```powershell
+> Invoke-WebRequest -Uri "https://github.com/tporadowski/redis/releases/download/v5.0.14.1/Redis-x64-5.0.14.1.zip" -OutFile "$env:TEMP\redis.zip" -UseBasicParsing
+> Expand-Archive -Path "$env:TEMP\redis.zip" -DestinationPath "$env:TEMP\redis" -Force
+> ```
+>
+> Verify it's up: `& "$env:TEMP\redis\redis-cli.exe" ping` → `PONG`
+
+### 2. Backend (FastAPI / Uvicorn)
+
+```powershell
+.venv\Scripts\Activate
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+- API base: `http://localhost:8000`
+- Swagger docs: `http://localhost:8000/docs`
+
+### 3. Frontend (React)
+
+```powershell
+cd app/frontend
+npm start
+```
+
+- App: `http://localhost:3000`
+- Dev-server proxy forwards `/api/*` requests to the backend on port 8000.
+
+### 4. Celery worker
+
+```powershell
+.venv\Scripts\python.exe -m celery -A app.tasks.pipeline_task.celery_app worker --loglevel=info --pool=solo
+```
+
+`--pool=solo` is **required on Windows** (Celery's default pool relies on `os.fork`, which isn't available).
+
+Worker is ready when you see:
+
+```
+[INFO/MainProcess] celery@<hostname> ready.
+```
+
+---
+
+## Session lifecycle
+
+When a user uploads a video, the session row moves through these states:
+
+| Status | Meaning |
+|---|---|
+| `uploading` | File being saved to disk |
+| `queued` | Task dispatched to Redis, waiting for a worker |
+| `pending` | Redis was unreachable at dispatch — re-dispatch needed |
+| `processing` | Worker has picked up the task |
+| `completed` | Pipeline finished; H.264 `.mp4` written, report parsed into DB |
+| `failed` | Pipeline errored — check the worker terminal |
+
+A successful run produces:
+
+- `output_videos/output_session_{id}_{n}_processed.mp4` — annotated H.264 video served to the browser via `GET /api/sessions/{id}/output_video`
+- `reports/session_{id}_{n}_report.txt` — text report parsed into `reports`, `shot_events`, and `angle_frames` rows
+
+---
+
+## Tests
+
+```powershell
+pytest -q
+```
+
+Tests override the app's `get_db` dependency to use a temporary SQLite database, so you don't need a separate test SQL Server.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `ConnectionRefusedError: [WinError 10061]` from uvicorn on upload | Redis isn't running — see step 1. |
+| `Data source name not found` (ODBC) | Install ODBC Driver 17 for SQL Server; set `DB_DRIVER` in `.env` to the exact installed driver name. |
+| `[08001] SQL Server does not exist or access denied` | Most likely `.env` is using the legacy `DB_DRIVER=SQL Server` (DBNETLIB) which can't reach the local instance. Switch to `ODBC Driver 17 for SQL Server`. |
+| `ModuleNotFoundError: No module named 'cv2'` (or `supervision`, `pandas`) in worker log | CV pipeline deps not installed. See "Known dependency gaps" → step 3 of one-time setup. |
+| Register/login returns 500, log shows `ValueError: password cannot be longer than 72 bytes` | bcrypt 4.x + passlib 1.7.4 incompatibility. `pip install "bcrypt==3.2.2"` and restart the backend. |
+| Annotated video player is blank but session shows `completed` | `imageio-ffmpeg` is missing, so output is left in `mp4v` codec which browsers won't play. `pip install imageio-ffmpeg`, restart the worker, and re-process. |
+| Session stuck at `queued` after Redis restart | Redis is in-memory — the queue is wiped on restart. Re-dispatch: `.venv\Scripts\python.exe -c "from app.tasks.pipeline_task import process_video; process_video.delay(<session_id>)"` |
+| Celery never picks up tasks on Windows | Make sure `--pool=solo` is on the command. |
+| `Stop-Process -Name python` killed uvicorn too | Both run as `python` — kill by PID instead: `Get-Process python \| Select Id, CommandLine` then `Stop-Process -Id <pid>`. |
+
+For more detail, see [`app/DEVELOPER_README.md`](app/DEVELOPER_README.md) §7.

--- a/docs/SwishVision_SDS.md
+++ b/docs/SwishVision_SDS.md
@@ -2,7 +2,7 @@
 
 ## SwishVision — Basketball Analytics Platform
 
-**Version:** 1.00
+**Version:** 1.10
 
 | Project Team | |
 |---|---|
@@ -11,7 +11,7 @@
 | Muhammad Ahmed Silat | |
 | Syed Muhammad Sameer Hassan | |
 
-| Submission Date | TBD |
+| Submission Date | 11th May 2026 |
 |---|---|
 
 ---
@@ -20,7 +20,9 @@
 
 | Version | Name of Person | Date | Description of Change |
 |---|---|---|---|
-| 1.00 | Ahmed Silat | 16th March | Initial draft — architecture and design documented |
+| 1.00 | Ahmed Silat | 16th March 2026 | Initial draft — architecture and design documented |
+| 1.10 | Minhaj ul Hassan | 11th May 2026 | Post-implementation update — finalised technology stack table, replaced PostgreSQL with SQL Server (pyodbc), updated file system layout to match shipped `app/` structure, updated environment variables to match `env.example` |
+| 1.11 | Minhaj ul Hassan | 11th May 2026 | Corrected output codec across the document — pipeline writes H.264 `.mp4` (via `mp4v` then `imageio-ffmpeg` transcode), not XVID `.avi`. Updated output filename pattern to the actual `output_session_{id}_{n}_processed.mp4` / `session_{id}_{n}_report.txt`. |
 
 ---
 
@@ -112,10 +114,10 @@ The pipeline executes the following 12 steps: (1) frame extraction via OpenCV, (
 - Pre-trained model files are available on the server under `models/`: `best.pt` (~43MB, fine-tuned YOLOv8 for ball/rim detection) and `yolov8m-pose.pt` (~78MB, Ultralytics pretrained medium pose model).
 - Additional model variants (`bestOld.pt`, `bestYT.pt`, `ballRim.pt`) exist but are not used in the primary pipeline.
 - Video storage is local filesystem-based for the current version. Cloud storage is acknowledged as a future migration path.
-- A relational database is available.
+- A Microsoft SQL Server 2019+ instance is available (Windows trusted connection or SQL auth) with the appropriate ODBC driver installed locally.
 - The server environment has Python 3.8+, `torch>=2.0.0`, `ultralytics>=8.0.0`, `opencv-python>=4.8.0`, `numpy>=1.24.0`, and `matplotlib>=3.7.0` installed.
 - The task queue uses Celery with Redis (or an equivalent) for managing background processing jobs.
-- Output videos are written in XVID codec as `.avi` files. The pipeline's `write_video()` function in `utils/vid_utils.py` handles this.
+- Output videos are written in two stages: `utils/vid_utils.py::write_video()` first writes frames as `.mp4` using OpenCV's `mp4v` fourcc, then transcodes to H.264 (`libx264`, `yuv420p`, `+faststart`) using the `ffmpeg` binary bundled by `imageio-ffmpeg`. The H.264 step is required for the React `<video>` player to play the file directly; if `imageio-ffmpeg` is missing the pipeline falls back to keeping the `mp4v` output, which most browsers will not play.
 - Intermediate data files (`angs.txt`, `xy_coords.txt`, `detections.txt`, `ball_locl.txt`) produced during processing are treated as transient and are not persisted to the database.
 - The `stubs_utils.py` module can be used to cache and reload intermediate tracking results, avoiding re-inference during development and testing.
 
@@ -123,7 +125,7 @@ The pipeline executes the following 12 steps: (1) frame extraction via OpenCV, (
 
 - **Model output variability:** The accuracy of ball and pose detection varies with video quality, lighting, and camera angle. Input should be 720p minimum at a side-on angle. If a video produces no detectable shots, the report will reflect zero detections — the pipeline handles this gracefully.
 - **Processing time unpredictability:** Inference time varies significantly based on video length and GPU availability. The README notes CUDA-compatible GPU is recommended; CPU-only will be substantially slower. The async job queue decouples upload from results, but the UI must communicate expected wait times clearly.
-- **File storage growth:** Uploaded videos and XVID `.avi` output files can be large. Without a cleanup or archival policy, disk usage will grow unbounded. A retention policy should be defined before production deployment.
+- **File storage growth:** Uploaded videos and H.264 `.mp4` output files can be large. Without a cleanup or archival policy, disk usage will grow unbounded. A retention policy should be defined before production deployment.
 - **Interpolation artefacts:** The ball track interpolation step (`interpolate_missing_tracks()`) can introduce false positives for short missing segments. This is a known limitation acknowledged in the existing codebase.
 - **Shot start detection sensitivity:** The `shot_started()` function in `utils/ball_hand.py` depends on pose keypoints and ball-hand distance estimates. Edge cases (e.g., player in unusual posture, occluded hand) may cause missed or duplicate shot start detections.
 - **Multiple model variants:** Several model files exist (`best.pt`, `bestOld.pt`, `bestYT.pt`, `ballRim.pt`). The web layer must use `best.pt` as the canonical production model; loading the wrong model variant would silently produce degraded results.
@@ -156,8 +158,8 @@ SwishVision follows a three-tier architecture:
        | File I/O
        |
 [ Storage Layer ]
-   - Database (PostgreSQL)
-   - Video File Store (local filesystem or S3)
+   - Database (Microsoft SQL Server via pyodbc)
+   - Video File Store (local filesystem: app/uploads/, output_videos/)
 ```
 
 The client browser communicates exclusively with the Web Application Server over HTTPS. Video processing is offloaded to a Background Worker via a task queue. The worker writes results to the database and file system, which the web server then reads and serves to the client.
@@ -193,14 +195,15 @@ A browser-based UI consuming the REST API. Key views: Landing/Login, Registratio
 
 | Layer | Technology |
 |---|---|
-| Frontend | TBD |
-| Backend Framework | TBD |
-| Task Queue | TBD |
-| Message Broker | TBD |
-| Database | SQL Server |
-| CV Pipeline | Python, PyTorch, Ultralytics YOLOv8, OpenCV |
-| Authentication | TBD |
-| Video Storage | Local filesystem |
+| Frontend | React 18 (Create React App), JavaScript, served by Node.js dev server in development; built static bundle in production |
+| Backend Framework | FastAPI 0.135 on Uvicorn 0.42 (ASGI) |
+| ORM / Migrations | SQLAlchemy 2.0 + Alembic 1.14 |
+| Task Queue | Celery 5.6 (worker run with `--pool=solo` on Windows) |
+| Message Broker | Redis 7+ (`redis://localhost:6379/0`) |
+| Database | Microsoft SQL Server 2019+ via `pyodbc` (`mssql+pyodbc` driver, ODBC Driver 17 for SQL Server) |
+| CV Pipeline | Python 3.8+, PyTorch ≥2.0, Ultralytics YOLOv8 ≥8.0, OpenCV ≥4.8 |
+| Authentication | JWT (HS256) via `python-jose`; passwords hashed with `bcrypt` (`passlib`) |
+| Video Storage | Local filesystem — `app/uploads/` (raw uploads) and `output_videos/` (annotated H.264 `.mp4`, named `output_session_{id}_{n}_processed.mp4`); reports written to `reports/session_{id}_{n}_report.txt` |
 
 ---
 
@@ -356,7 +359,7 @@ HumanTracksDrawer                                   # drawers/human_tracks_drawe
 
 # utils/vid_utils.py
 read_video(path: str) → (frames: list, fps: float)
-write_video(frames: list, path: str, fps: float) → void   # XVID codec, .avi output
+write_video(frames: list, path: str, fps: float) → void   # mp4v → transcoded to H.264 .mp4 via imageio-ffmpeg
 
 # utils/ball_hand.py
 ball_hand(ball_loco, points, frames) → list         # Returns ball_left_frames
@@ -379,7 +382,7 @@ Session
   - user_id: UUID
   - video_filename: str                             # Original upload name
   - video_path: str                                 # Server storage path
-  - output_video_path: str                          # XVID .avi output path
+  - output_video_path: str                          # H.264 .mp4 output path
   - report_file_path: str                           # Path to .txt report
   - status: str                                     # queued|processing|completed|failed
   - upload_time: datetime
@@ -505,7 +508,7 @@ API Server → Player Browser: Video stream (chunked)
 19. Run `HumanTracksDrawer.analysis(frames, angles, ball_left_frames, shot_starts, report_path)` → annotated frames + report `.txt` written to `reports/`
 20. Run `ShotTracker.detect_shot(frames, interpolated_ball_tracks, rim_tracks)`
 21. Run `ShotTracker.draw_shots(frames)` → final annotated frames
-22. Run `write_video(frames, output_path, fps)` → XVID `.avi` written to `output_videos/`
+22. Run `write_video(frames, output_path, fps)` → H.264 `.mp4` written to `output_videos/output_session_{id}_{n}_processed.mp4` (via `mp4v` then `imageio-ffmpeg` transcode to `libx264`)
 23. Parse `{vidname}_report.txt`; INSERT into `reports`, `shot_events`, `angle_frames` tables
 24. UPDATE session status = `completed`, set `completed_time`
 25. Clean up transient intermediate files (`angs.txt`, `xy_coords.txt`, `detections.txt`, `ball_locl.txt`)
@@ -597,30 +600,59 @@ Swish-Vision/                        ← Project root
 ├── models/                          ← Model weights (best.pt, yolov8m-pose.pt, variants)
 │
 ├── input_videos/                    ← Worker copies uploaded video here before processing
-├── output_videos/                   ← Pipeline writes XVID .avi output here
+├── output_videos/                   ← Pipeline writes H.264 .mp4 output here
 ├── reports/                         ← Pipeline writes {vidname}_report.txt here
 │
 ├── Basketball-1/                    ← Training dataset (Roboflow, not used at runtime)
 ├── runs/                            ← YOLO training run history (not used at runtime)
 │
-└── [Web Application Layer]          ← New components added for web version
-    ├── app/                         ← FastAPI/Flask application
-    │   ├── api/                     ← Route handlers
-    │   ├── models/                  ← SQLAlchemy ORM models
-    │   ├── tasks/                   ← Celery task definitions (wraps main_pipeline)
-    │   └── frontend/                ← HTML/CSS/JS frontend
-    ├── uploads/                     ← Raw user-uploaded videos (pre-processing)
-    └── .env                         ← Environment variables
+└── app/                            ← Web application layer (delivered)
+    ├── main.py                     ← FastAPI app factory + lifespan
+    ├── config.py                   ← Pydantic Settings (reads .env)
+    ├── database.py                 ← SQLAlchemy engine + SessionLocal (mssql+pyodbc)
+    ├── api/
+    │   ├── auth.py                 ← /api/auth/* (register, login, logout, JWT)
+    │   ├── sessions.py             ← /api/sessions/* (upload, list, get, delete, report, shots, video)
+    │   └── dashboard.py            ← /api/dashboard/* (summary, trends)
+    ├── core/
+    │   ├── security.py             ← bcrypt + JWT helpers, get_current_user dependency
+    │   └── middleware.py           ← CORS, security headers, optional HTTPS redirect
+    ├── models/                     ← SQLAlchemy ORM models
+    │   ├── user.py
+    │   ├── session.py
+    │   ├── report.py
+    │   ├── shot_event.py
+    │   ├── angle_frame.py
+    │   └── revoked_token.py
+    ├── schemas/                    ← Pydantic request/response schemas
+    ├── tasks/
+    │   ├── pipeline_task.py        ← Celery app + process_video task
+    │   └── report_parser.py        ← Parses {vidname}_report.txt → DB rows
+    ├── migrations/                 ← Alembic environment + versions/
+    ├── frontend/                   ← React (Create React App)
+    │   ├── package.json
+    │   ├── public/
+    │   └── src/                    ← App.js, AuthContext.js, NavBar.jsx, pages/, components/
+    ├── uploads/                    ← Raw user-uploaded videos (pre-processing)
+    ├── requirements.txt            ← Backend Python dependencies
+    └── DEVELOPER_README.md         ← Web-app-specific developer guide
 ```
 
 ### Appendix C — Environment Variables
 
 | Variable | Description |
 |---|---|
-| `DATABASE_URL` | Connection string for PostgreSQL |
-| `REDIS_URL` | Connection string for Redis broker |
-| `SECRET_KEY` | JWT signing secret |
-| `UPLOAD_DIR` | Absolute path for video uploads |
-| `OUTPUT_DIR` | Absolute path for processed outputs |
-| `MODEL_DIR` | Absolute path to model files |
-| `MAX_UPLOAD_SIZE_MB` | Maximum allowed video upload size |
+| `ENV` | Environment name: `development` \| `staging` \| `production` (controls HTTPS redirect middleware) |
+| `DB_SERVER` | SQL Server hostname/instance (e.g. `localhost`) |
+| `DB_NAME` | SQL Server database name (e.g. `SwishVision`) |
+| `DB_DRIVER` | ODBC driver name (e.g. `ODBC Driver 17 for SQL Server`) |
+| `DB_TRUSTED_CONNECTION` | `true` for Windows auth; `false` to use `DB_USERNAME`/`DB_PASSWORD` |
+| `DB_USERNAME` / `DB_PASSWORD` | SQL auth credentials (only when `DB_TRUSTED_CONNECTION=false`) |
+| `REDIS_URL` | Redis connection string for the Celery broker (e.g. `redis://localhost:6379/0`) |
+| `CELERY_RESULT_BACKEND` | Celery result backend URL (typically same as `REDIS_URL`) |
+| `SECRET_KEY` | JWT signing secret — must be replaced before any non-local deploy |
+| `ADMIN_RESET_KEY` | Shared secret required for `POST /api/auth/admin/force-reset-password` |
+| `UPLOAD_DIR` | Path for raw uploaded videos (default `app/uploads`) |
+| `OUTPUT_DIR` | Path for annotated H.264 `.mp4` outputs (default `output_videos`) |
+| `MODEL_DIR` | Path to YOLOv8 model weights (default `models`) |
+| `MAX_UPLOAD_SIZE_MB` | Maximum allowed video upload size in MB (default `500`) |

--- a/docs/SwishVision_SRS.md
+++ b/docs/SwishVision_SRS.md
@@ -2,7 +2,7 @@
 
 ## SwishVision — Basketball Analytics Platform
 
-**Version:** 1.00
+**Version:** 1.10
 
 | Project Team | |
 |---|---|
@@ -11,7 +11,7 @@
 | Muhammad Ahmed Silat | |
 | Syed Muhammad Sameer Hassan | |
 
-| Submission Date | TBD |
+| Submission Date | 11th May 2026 |
 |---|---|
 
 ---
@@ -20,7 +20,9 @@
 
 | Version | Name of Person | Date | Description of Change |
 |---|---|---|---|
-| 1.00 | Ahmed Silat | 16th March | Initial draft — project proposal translated to SRS |
+| 1.00 | Ahmed Silat | 16th March 2026 | Initial draft — project proposal translated to SRS |
+| 1.10 | Minhaj ul Hassan | 11th May 2026 | Post-implementation update — locked in tech stack (FastAPI / React / SQL Server / Celery+Redis / JWT), reflected delivered scope, marked all use cases as implemented |
+| 1.11 | Minhaj ul Hassan | 11th May 2026 | Corrected output codec to H.264 MP4 (transcoded via `imageio-ffmpeg`), added `imageio-ffmpeg`, `supervision`, and `pandas` to the Software Interfaces inventory |
 
 ---
 
@@ -149,7 +151,7 @@ Evaluates the project from an academic standpoint. Requires documentation, worki
 - **RAM:** Minimum 4GB; 8GB+ recommended for smooth inference
 - **Storage:** Minimum 10GB for model files, uploaded videos, and generated outputs
 - **Network:** Standard HTTPS internet connection for the client; server requires sufficient bandwidth for video uploads
-- **Output Codec:** XVID (AVI container) for processed output videos
+- **Output Codec:** H.264 in MP4 container — frames are written with OpenCV's `mp4v` fourcc and then transcoded to H.264 (`yuv420p`, `+faststart`) via `imageio-ffmpeg` so the result plays directly in `<video>` elements in Chrome / Firefox / Safari / Edge. If `imageio-ffmpeg` is unavailable the pipeline keeps the `mp4v` output as a fallback (not browser-playable).
 
 ### 2.7 System Constraints
 
@@ -180,15 +182,15 @@ An **Incremental Development** methodology will be used. This choice is appropri
 - Early increments (video upload + basic results) can be demonstrated to the supervisor for feedback before more advanced features (dashboard, history, detailed analytics) are built.
 - The team can parallelize work on the backend processing pipeline and the frontend interface.
 
-**Planned Increments:**
+**Delivered Increments (all completed as of 11th May 2026):**
 
-| Increment | Deliverable |
-|---|---|
-| 1 | User registration/login + video upload endpoint |
-| 2 | Background processing integration — pipeline runs on uploaded video |
-| 3 | Shot detection results displayed on frontend |
-| 4 | Pose/form analysis results and report generation |
-| 5 | Session history and longitudinal dashboard |
+| Increment | Deliverable | Status |
+|---|---|---|
+| 1 | User registration/login + video upload endpoint | ✅ Delivered |
+| 2 | Background processing integration — pipeline runs on uploaded video via Celery | ✅ Delivered |
+| 3 | Shot detection results displayed on frontend (React) | ✅ Delivered |
+| 4 | Pose/form analysis results and report generation | ✅ Delivered |
+| 5 | Session history and longitudinal dashboard | ✅ Delivered |
 
 ---
 
@@ -218,12 +220,17 @@ Requirements were gathered through the following approaches:
 - **Python 3.8+** — core runtime for the CV pipeline
 - **Ultralytics YOLOv8** (`ultralytics>=8.0.0`) — object detection and pose estimation
 - **PyTorch 2.0+** (`torch>=2.0.0`, `torchvision>=0.15.0`) — deep learning inference backend
-- **OpenCV** (`opencv-python>=4.8.0`) — video reading, frame processing, and output writing (XVID codec)
+- **OpenCV** (`opencv-python>=4.8.0`) — video reading, frame processing, and initial frame writing (`mp4v` fourcc); final transcoded H.264 output is produced by `imageio-ffmpeg`
+- **imageio-ffmpeg** — bundles a static `ffmpeg` binary used to transcode pipeline output from `mp4v` to browser-playable H.264 MP4
+- **supervision** + **pandas** — used by the trackers (`BallTracker`, `RimTracker`, `HumanTracker`)
 - **NumPy** (`numpy>=1.24.0`) — array operations and numerical calculations
 - **Matplotlib** (`matplotlib>=3.7.0`) — plotting and visualization within reports
-- **Web Framework (e.g., Flask or ASP.NET)** — to expose the pipeline as a web service
-- **Database (SQL Server)** — to store user accounts, session metadata, and report data
-- **Task Queue (e.g., Celery + Redis, or equivalent)** — to manage asynchronous video processing jobs
+- **FastAPI** (`fastapi==0.135.3`, `uvicorn==0.42.0`) — backend web framework and ASGI server
+- **React** (Create React App, Node.js 18+) — frontend single-page application served on port 3000 in dev with a proxy to the FastAPI backend on port 8000
+- **SQLAlchemy** (`SQLAlchemy==2.0.48`) + **Alembic** (`alembic==1.14.1`) — ORM and migrations
+- **Microsoft SQL Server 2019+** with **pyodbc** (`pyodbc==5.3.0`, ODBC Driver 17 for SQL Server) — relational store for users, sessions, reports, shot events, and angle frames
+- **Celery** (`celery==5.6.3`) + **Redis 7+** (`redis==5.2.1`) — asynchronous task queue and message broker for video processing jobs (Celery worker uses `--pool=solo` on Windows)
+- **JWT authentication** — `python-jose[cryptography]==3.5.0` for tokens, `passlib[bcrypt]==1.7.4` + `bcrypt==4.0.1` for password hashing
 - **Web Browser** — Chrome, Firefox, Safari, or Edge (client side)
 
 ### 5.3 Communications Interfaces


### PR DESCRIPTION
- Bump SRS to v1.11 and SDS to v1.11 with finalised tech stack (FastAPI / React / SQL Server / Celery+Redis / JWT) and corrected output codec (H.264 mp4 transcoded via imageio-ffmpeg, not XVID avi)
- Move root-level SRS/SDS into docs/ to consolidate documentation
- Add root DEVELOPER_README.md with the full one-time setup, the four-terminal run sequence, and the install gaps we hit while bringing the system up end-to-end (missing CV deps, bcrypt 4 vs passlib 1.7.4, imageio-ffmpeg required for browser-playable output, legacy "SQL Server" ODBC driver vs "ODBC Driver 17")